### PR TITLE
Minor typo fix: 'Huntingdon' -> 'Huntington'

### DIFF
--- a/acknowledgements.md
+++ b/acknowledgements.md
@@ -33,6 +33,7 @@ If you make a pull request, please also add your name here in the alphabetical o
 * Brian Sapozhnikov
 * Josh Seides
 * Alaisha Sharma
+* Miguel Solano
 * Hikari Sorensen
 * David Steurer
 * Alec Sun

--- a/lec_03_computation.md
+++ b/lec_03_computation.md
@@ -48,7 +48,7 @@ Here is how al-Khwarizmi described how to solve an equation of the form $x^2 +bx
 ![An explanation for children of the two digit addition algorithm](../figure/addition_regrouping.jpg){#childrenalg .class width=300px height=300px}
 
 
-![Text pages from Algebra manuscript with geometrical solutions to two quadratic equations. Shelfmark: MS. Huntingdon 214 fol. 004v-005r](../figure/alKhwarizmi.jpg){#alKhwarizmi .class width=300px height=300px}
+![Text pages from Algebra manuscript with geometrical solutions to two quadratic equations. Shelfmark: MS. Huntington 214 fol. 004v-005r](../figure/alKhwarizmi.jpg){#alKhwarizmi .class width=300px height=300px}
 
 For the purposes of this course, we will need a much more precise way to define algorithms.
 Fortunately (or is it unfortunately?), at least at the moment, computers lag far behind school-age children in learning from examples.


### PR DESCRIPTION
Just a minor typo fix to the shelfmark to Al-Khwārizmī's MS in Fig 3.4: should read 'Huntington', not 'Huntingdon'. (Cf. [1])

[1] http://bodley30.bodley.ox.ac.uk:8180/luna/servlet/s/26tvvj
