### PR TITLE
Remove duplicated list element

### DIFF
--- a/lec_07_other_models.md
+++ b/lec_07_other_models.md
@@ -382,7 +382,6 @@ Some examples of Turing equivalent models (some of which we have already seen, a
 * Turing machines
 * NAND-TM programs
 * NAND-RAM programs
-* Python, JavaScript, C, Lisp, and other programming languages.
 * λ calculus
 * Game of life (mapping programs and inputs/outputs to starting and ending configurations)
 * Programming languages such as Python/C/Javascript/OCaml... (allowing for unbounded storage)


### PR DESCRIPTION
I think that the line `* Python, JavaScript, C, Lisp, and other programming languages.` is redundant with the last element in the list.