### PR TITLE
Fix typos in ch2-6

### DIFF
--- a/acknowledgements.md
+++ b/acknowledgements.md
@@ -14,6 +14,7 @@ If you make a pull request, please also add your name here in the alphabetical o
 * Chi-Ning Chou
 * Michael Colavita
 * Robert Darley Waddilove
+* Rodrigo Daboin Sanchez
 * Juan Esteller
 * David Evans
 * Michael Fine

--- a/lec_02_representation.md
+++ b/lec_02_representation.md
@@ -281,7 +281,7 @@ Indeed, this is one instance of a very general principle that we use time and ag
 
 
 ::: { .bigidea #representtuplesidea }
-If we can represent objects of type $T$ as strings, then we can represents tuples of objects of type $T$ as strings as well.
+If we can represent objects of type $T$ as strings, then we can represent tuples of objects of type $T$ as strings as well.
 :::
 
 Repeating the same idea, once we can represent objects of type $T$, we can also represent _lists of lists_ of such objects, and even  lists of lists of lists and so on and so forth.

--- a/lec_02_representation.md
+++ b/lec_02_representation.md
@@ -174,9 +174,9 @@ So what is the "actual" number? This is a question that philosophers of mathemat
 Plato argued that mathematical objects exist in some ideal sphere of existence (that to a certain extent is more "real" than the world we perceive via our senses, as this latter world is merely the shadow of this ideal sphere).
 In Plato's vision, the symbols $236$ are merely notation for some ideal object, that, in homage to the [late musician](https://goo.gl/b93h83), we can refer to as  "the number commonly represented by $236$".
 
-The Austrian philosopher Ludwig Wittgenstein, on the other hand, argued that mathematical objects do not exist at all, and the only things that exist are the actual marks on paper that make up $236$, $00110111$ or `CCXXXVI`.
+The Austrian philosopher Ludwig Wittgenstein, on the other hand, argued that mathematical objects do not exist at all, and the only things that exist are the actual marks on paper that make up $236$, $11101100$ or `CCXXXVI`.
 In Wittgenstein's view, mathematics is merely about formal manipulation of symbols that do not have any inherent meaning.
-You can think of the "actual" number as (somewhat recursively) "that thing which is common to $236$, $00110111$  and `CCXXXVI` and all other past and future representations that are meant to capture the same object".
+You can think of the "actual" number as (somewhat recursively) "that thing which is common to $236$, $11101100$  and `CCXXXVI` and all other past and future representations that are meant to capture the same object".
 
 While reading this book, you are free to choose your own philosophy of mathematics, as long as you maintain the distinction between the mathematical objects themselves and the various particular choices of representing them, whether as splotches of ink, pixels on a screen, zeroes and one, or any other form.
 

--- a/lec_02_representation.md
+++ b/lec_02_representation.md
@@ -63,7 +63,7 @@ Moreover, once information is in digital form, we can _compute_ over it, and gai
 At the heart of this revolution is the simple but profound observation that we can represent an unbounded variety of objects using a finite set of symbols (and in fact using only the two symbols `0` and `1`).
 
 In later chapters, we will typically take such representations for granted, and hence use expressions such as "program $P$ takes $x$ as input" when $x$ might be a number, a vector, a graph, or any other object,  when we really mean that $P$ takes as input the _representation_ of $x$ as a binary string.
-However, in this chapter we will dwell a bit more on how we can construct such representations. 
+However, in this chapter we will dwell a bit more on how we can construct such representations.
 
 ## Defining representations
 
@@ -106,7 +106,7 @@ Some more examples are given in the table below.
 | 389                                 | 110000101                          |
 | 3750                                | 111010100110                       |
 
-Table: Representing numbers in the binary basis. The lefthand column contains representations of natural numbers in the decimal basis, while the righthand column contains representations of the same numbers in the binary basis. 
+Table: Representing numbers in the binary basis. The lefthand column contains representations of natural numbers in the decimal basis, while the righthand column contains representations of the same numbers in the binary basis.
 
 If $n$ is even, then the least significant digit of $n$'s binary representation is $0$, while if $n$ is odd then this digit equals $1$.
 Just like the number $\floor{n/10}$ corresponds to "chopping off" the least significant decimal digit (e.g., $\floor{457/10}=\floor{45.7}=45$), the number $\floor{n/2}$ corresponds to the "chopping off" the least significant _binary_ digit.
@@ -118,11 +118,11 @@ $$NtS(n) = \begin{cases}
             NtS(\floor{n/2}) parity(n) & n>1
 \end{cases} \label{ntseq}$$
 where $parity:\N \rightarrow \{0,1\}$  is the function defined as $parity(n)=0$ if $n$ is even and $parity(n)=1$ if $n$ is odd, and as usual, for strings $x,y \in \{0,1\}^*$, $xy$ denotes the concatenation of $x$ and $y$.
-The function $NtS$ is defined _recursively_: for every $n>0$ we define $rep(n)$ in terms of the representation of the smaller number $\floor{n/2}$. 
+The function $NtS$ is defined _recursively_: for every $n>0$ we define $rep(n)$ in terms of the representation of the smaller number $\floor{n/2}$.
 It is also possible to define $NtS$ non-recursively, see [binaryrepex](){.ref}.
 
 Throughout most of this book, the particular choices of representation of numbers as binary strings would not matter much, we just need to know that such a representation exists.
-In fact, for most  purposes, we can even use the simpler representation of mapping a natural number $n$ to the length-$n$ all-zero string $0^n$. 
+In fact, for most  purposes, we can even use the simpler representation of mapping a natural number $n$ to the length-$n$ all-zero string $0^n$.
 
 
 ::: {.remark title="Binary representation in python (optional)" #pythonbinary}
@@ -223,7 +223,7 @@ $$
 ZtS_n(k) = \begin{cases} NtS_{n+1}(k) & 0 \leq k \leq 2^n-1 \\
                      NtS_{n+1}(2^{n+1}+k) & -2^n \leq k \leq -1 \end{cases} \;,
 $$
-where $NtS_\ell(m)$ demotes the standard binary representation of a number  $m \in \{0,\ldots, 2^{\ell}\}$ as string of length $\ell$, padded with leading zeros as needed. 
+where $NtS_\ell(m)$ demotes the standard binary representation of a number  $m \in \{0,\ldots, 2^{\ell}\}$ as string of length $\ell$, padded with leading zeros as needed.
 For example, if $n=3$ then $ZtS_3(1)=NtS_4(1)=0001$, $ZtS_3(2)=NtS_4(2)=0010$, $ZtS_3(-1)=NtS_4(16-1)=1111$, and $ZtS_3(-8)=NtS_4(16-8)=1000$.
 If $k$ is a  negative number larger or equal to $-2^n$ then  $2^{n+1}+k$ is a number between $2^n$ and $2^{n+1}-1$.
 Hence the two's complement representation of such a number $k$ is a string of length $n+1$  with its first digit equal to $1$.
@@ -259,7 +259,7 @@ Our final representation for rational numbers is obtained by composing the follo
 
 1. Representing a non-negative rational number as a pair of natural numbers.
 
-2. Representing a natural number by a string via the binary representation. 
+2. Representing a natural number by a string via the binary representation.
 
 3. Combining 1 and 2 to obtain a representation of a rational number as a pair of strings.
 
@@ -281,7 +281,7 @@ Indeed, this is one instance of a very general principle that we use time and ag
 
 
 ::: { .bigidea #representtuplesidea }
-If we can represent objects of type $T$ as strings, then we can represents tuples of objects of type $T$ as strings as well. 
+If we can represent objects of type $T$ as strings, then we can represents tuples of objects of type $T$ as strings as well.
 :::
 
 Repeating the same idea, once we can represent objects of type $T$, we can also represent _lists of lists_ of such objects, and even  lists of lists of lists and so on and so forth.
@@ -319,7 +319,7 @@ For example, floating point rounding errors have been implicated in the   [failu
 
 ### Can we represent reals _exactly_? {#cantorsec }
 
-Given the issues with floating point approximations for real numbers, 
+Given the issues with floating point approximations for real numbers,
 a natural question is whether it is possible to  represent real numbers _exactly_ as strings.
 Unfortunately, the following theorem shows that this cannot be done:
 
@@ -402,7 +402,7 @@ We assume, towards a contradiction, that there exists such a function $StF:\{0,1
 We will show that $StF$ is not onto by demonstrating a function $\overline{d}\in \{0,1\}^\infty$ such that $\overline{d} \neq StF(x)$ for every $x\in \{0,1\}^*$.
 Consider the lexicographic ordering of binary strings (i.e., $""$,$0$,$1$,$00$,$01$,$\ldots$).
 For every $n\in \N$, we let $x_n$ be the $n$-th string in this order.
-That is $x_0 =""$, $x_1 = 0$, $x_2=00$ and so on and so forth.
+That is $x_0 =""$, $x_1 = 0$, $x_2= 1$ and so on and so forth.
 We define the function $\overline{d} \in \{0,1\}^\infty$ as follows:
 $$\overline{d}(n) = 1 - StF(x_n)(n)$$
 for every $n\in \N$.
@@ -411,7 +411,7 @@ Since $g \in \{0,1\}^\infty$, it is a function mapping $\N$ to $\{0,1\}$.
 The value $\overline{d}(n)$ is defined to be the negation of $g(n)$.
 
 The definition of the function $\overline{d}$ is a bit subtle.
-One way to think about it is to imagine the function $StF$ as being specified by an infinitely long table, in which every row corresponds to a string $x\in \{0,1\}^*$ (with strings sorted in lexicographic order), and contains the sequence $StF(x)(0), StF(x)(1), StF(x)(2),\ldots$. 
+One way to think about it is to imagine the function $StF$ as being specified by an infinitely long table, in which every row corresponds to a string $x\in \{0,1\}^*$ (with strings sorted in lexicographic order), and contains the sequence $StF(x)(0), StF(x)(1), StF(x)(2),\ldots$.
 The _diagonal_ elements in this table   are the values
 
 $$StF("")(0),StF(0)(1),StF(1)(2),StF(00)(3), StF(01)(4),\ldots$$
@@ -421,7 +421,7 @@ The function $\overline{d}$ we defined above maps every $n\in \N$ to the negatio
 
 To complete the proof that $StF$ is not onto we need to show that $\overline{d} \neq StF(x)$ for every $x\in \{0,1\}^*$.
 Indeed, let $x\in \{0,1\}^*$ be some string and let $g = StF(x)$.
-If $n$ is the position of $x$ in the lexicographical order then by construction $\overline{d}(n) = 11-g(n) \neq g(n)$ which means that $g \neq \overline{d}$ which is what we wanted to prove. 
+If $n$ is the position of $x$ in the lexicographical order then by construction $\overline{d}(n) = 11-g(n) \neq g(n)$ which means that $g \neq \overline{d}$ which is what we wanted to prove.
 :::
 
 ::: {.pause}
@@ -458,7 +458,7 @@ This part is not the core of Cantor's argument, nor are such limits important to
 
 
 ::: {.proofidea data-ref="sequencestoreals"}
-We define $FtR(f)$ to be the number between $0$ and $2$ whose decimal expansion is $f(0).f(1) f(2) \ldots$, or in other words  $FtR(f) = \sum_{i=0}^{\infty} f(i) \cdot 10^{-i}$. 
+We define $FtR(f)$ to be the number between $0$ and $2$ whose decimal expansion is $f(0).f(1) f(2) \ldots$, or in other words  $FtR(f) = \sum_{i=0}^{\infty} f(i) \cdot 10^{-i}$.
 To prove that $FtR$ is one to one, we need to show that if $f \neq g$ then $FtR(f) \neq FtR(g)$.
 To do that we let $k\in \N$ be the first input on which $f$ and $g$ disagree.
 The numbers $FtR(f)$ and $FtR(g)$ agree in the first $k-2$ digits following the decimal point and disagree in the $k-1$-th digit. One can then calculate and verify that this means that $|FtR(f)-FtR(g)| > 0.5 \cdot 10^{-k}$ which in particular means that these two numbers are distinct from one another. (You might wonder why we can't immediately deduce that two numbers that differ in a digit are not the same. The issue is that we have to be a little more careful when talking about infinite expansions. For example, the number one half has two decimal expansions $0.5$ and $0.49999\cdots$. However, this issue does not come up if (as in our case) we restrict attention only to numbers with decimal expansions that do not involve the digit $9$.)
@@ -468,7 +468,7 @@ The numbers $FtR(f)$ and $FtR(g)$ agree in the first $k-2$ digits following the 
 
 For every $f \in \{0,1\}^\infty$,  we define $FtR(f)$ to be the number whose decimal expansion is $f(0).f(1)f(2)f(3)\ldots$.
 
-Formally we define 
+Formally we define
 $$
 FtR(f) = \sum_{i=0}^\infty f(i) \cdot 10^{-i} \label{eqcantordecimalexpansion}
 $$
@@ -526,7 +526,7 @@ For every $x \in \{0,1\}^*$, there exists either zero or a single $o\in \mathcal
 We will define $D(x)$ to equal $o_0$ in the first case and this single object $o$ in the second case.
 By definition $D(E(o))=o$ for every $o\in \mathcal{O}$.
 
-::: {.remark title="Total decoding functions" #totaldecoding} 
+::: {.remark title="Total decoding functions" #totaldecoding}
 While the decoding function of a representation scheme can in general be a _partial_ function,  the proof of [decodelem](){.ref} implies that every representation scheme has a _total_ decoding function. This observation can sometimes be useful.
 :::
 
@@ -671,15 +671,15 @@ For the sake of completeness, we will include the proof below, but it is a good 
 ::: {.proof data-ref="prefixfreetransformationlem"}
 The idea behind the proof is to use the map $0 \mapsto 00$, $1 \mapsto 11$ to "double" every bit in the string $x$ and then mark the end of the string by concatenating to it the pair $01$.
 If we encode a string $x$ in this way, it ensures that the encoding of $x$ is never a prefix of the encoding of a distinct string $x'$.
-Formally, we define the function $PF:\{0,1\}^* \rightarrow \{0,1\}^*$ as follows: 
-$$PF(x)=x_0 x_0 x_1 x_1 \ldots x_{n-1}x_{n-1}01$$ 
+Formally, we define the function $PF:\{0,1\}^* \rightarrow \{0,1\}^*$ as follows:
+$$PF(x)=x_0 x_0 x_1 x_1 \ldots x_{n-1}x_{n-1}01$$
 for every $x\in \{0,1\}^*$.
 If $E:\mathcal{O} \rightarrow \{0,1\}^*$ is the (potentially not prefix-free) representation for $\mathcal{O}$, then we transform it into a prefix-free representation $\overline{E}:\mathcal{O} \rightarrow \{0,1\}^*$ by defining $\overline{E}(o)=PF(E(o))$.
 
 To prove the lemma we need to show that __(1)__ $\overline{E}$ is one-to-one and __(2)__ $\overline{E}$ is prefix-free.
 In fact, prefix freeness is a stronger condition than one-to-one (if two strings are equal then in particular one of them is a prefix of the other) and hence it suffices to prove __(2)__, which we now do.
 
-Let $o \neq o'$ in $\mathcal{O}$ be two distinct objects. We will prove  that $\overline{E}(o)$ is a not a prefix of $\overline{E}(o')$. 
+Let $o \neq o'$ in $\mathcal{O}$ be two distinct objects. We will prove  that $\overline{E}(o)$ is a not a prefix of $\overline{E}(o')$.
 Define $x = E(o)$ and $x'=E(o')$.
 Since $E$ is one-to-one, $x \neq x'$.
 Under our assumption, $PF(x)$ is a prefix of $PF(x')$.
@@ -690,7 +690,7 @@ In all cases we see that $PF(x)=\overline{E}(o)$ is not a prefix of $PF(x')=\ove
 :::
 
 The proof of [prefixfreetransformationlem](){.ref} is not the only or even the best way to transform an arbitrary representation into prefix-free form.
-[prefix-free-ex](){.ref} asks you to construct a more efficient prefix-free transformation satisfying $|\overline{E}(o)| \leq |E(o)| + O(\log |E(o)|)$. 
+[prefix-free-ex](){.ref} asks you to construct a more efficient prefix-free transformation satisfying $|\overline{E}(o)| \leq |E(o)| + O(\log |E(o)|)$.
 
 ### "Proof by Python" (optional)
 
@@ -750,7 +750,7 @@ def represlists(pfencode,pfdecode,pfvalid):
     """
     Takes functions pfencode, pfdecode and pfvalid,
     and returns functions encodelists, decodelists
-    that can encode and decode lists of the objects 
+    that can encode and decode lists of the objects
     respectively.
     """
 
@@ -1145,7 +1145,7 @@ The study of representing data as strings, including issues such as _compression
 Representations are also studied in the field of _data structures design_, as covered in texts such as  [@CLRS].
 
 The question of whether to represent integers with most significant digit first or last is known as [Big Endian vs. Little Endian](https://betterexplained.com/articles/understanding-big-and-little-endian-byte-order/) representation.
-This terminology comes from Cohen's [@cohen1981holy]  entertaining and informative paper about the conflict between adherents of both schools which he compared to the warring tribes in Jonathan Swift's _"Gulliver's Travels"_. 
+This terminology comes from Cohen's [@cohen1981holy]  entertaining and informative paper about the conflict between adherents of both schools which he compared to the warring tribes in Jonathan Swift's _"Gulliver's Travels"_.
 The two's complement representation of signed integers was suggested in von Neumann's classic report [@vonNeumann45] that detailed the design approaches for a stored-program computer, though similar representations have been used even earlier in abacus and other mechanical computation devices.
 
 
@@ -1161,4 +1161,3 @@ The  [Floating Points Guide website](https://floating-point-gui.de/) contains an
 Dauben [@Dauben90cantor] gives a biography of Cantor with emphasis on the development of his mathematical ideas. [@halmos1960naive] is a classic textbook on set theory, including also Cantor's theorem. Cantor's Theorem is also covered in many texts on discrete mathematics, including  [@LehmanLeightonMeyer , @LewisZax19].
 
 The adjacency matrix representation of graphs is not merely a convenient way to map a graph into a binary string, but it turns out that many natural notions and operations on matrices are useful for graphs as well. (For example, Google's PageRank algorithm relies on this viewpoint.)  The notes of [Spielman's course](http://www.cs.yale.edu/homes/spielman/561/) are an excellent source for this area, known as _spectral graph theory_. We will return to this view much later in this book when we talk about _random walks_.
-

--- a/lec_03_computation.md
+++ b/lec_03_computation.md
@@ -687,7 +687,7 @@ In particular we can reduce the setting of real inputs to binary inputs by repre
 We can implement computation using many other physical media, without any electronic, biological, or chemical components. Many suggestions for _mechanical_ computers have been put forward, going back at least to Gottfried Leibniz' computing machines from the 1670s and Charles Babbage's 1837 plan for a mechanical ["Analytical Engine"](https://en.wikipedia.org/wiki/Analytical_Engine).
 As one example, [marblefig](){.ref} shows a simple implementation of a NAND (negation of AND, see [nandsec](){.ref}) gate using marbles going through pipes. We represent a logical value in $\{0,1\}$ by a pair of pipes, such that there is a marble flowing through exactly one of the pipes.
 We call one of the pipes the "$0$ pipe" and the other the "$1$ pipe", and so the identity of the pipe containing the marble determines the logical value.
-A NAND gate  corresponds to a mechanical object with two pairs of incoming pipes and one pair of outgoing pipes, such that for every $a,b \in \{0,1\}$, if two marble are rolling toward the object in the $a$ pipe of the first pair and the $b$ pipe of the second pair, then a marble will roll out of the object in the $NAND(a,b)$-pipe of the outgoing pair.
+A NAND gate  corresponds to a mechanical object with two pairs of incoming pipes and one pair of outgoing pipes, such that for every $a,b \in \{0,1\}$, if two marbles are rolling toward the object in the $a$ pipe of the first pair and the $b$ pipe of the second pair, then a marble will roll out of the object in the $NAND(a,b)$-pipe of the outgoing pair.
 In fact, there is even a commercially-available educational game that uses marbles as a basis of computing, see [turingtumblefig](){.ref}.
 
 

--- a/lec_03_computation.md
+++ b/lec_03_computation.md
@@ -11,7 +11,7 @@ chapternum: "3"
 * See that computation can be precisely modeled. \
 * Learn the computational model of _Boolean circuits_ / _straight-line programs_.
 * Equivalence of circuits and straight-line programs.
-* Equivalence of  AND/OR/NOT and  NAND. 
+* Equivalence of  AND/OR/NOT and  NAND.
 * Examples of computing in the physical world. \
 
 
@@ -36,7 +36,7 @@ A priori, the notion of computation seems to be tied to the particular mechanism
 You might think that the "best"  algorithm for multiplying numbers will differ if you implement it in _Python_ on a modern laptop than if you use pen and paper.
 However, as we saw in the introduction ([chapintro](){.ref}), an algorithm that is asymptotically better would eventually beat a worse one regardless of the underlying technology.
 This gives us hope for a _technology independent_ way of defining computation.
-This is what we do in this chapter. 
+This is what we do in this chapter.
 We will define the notion of computing an output from an input by applying a sequence of basic operations (see [compchapwhatvshowfig](){.ref}).
 Using this, we will be able to precisely define statements such as "function $f$ can be computed by model $X$" or "function $f$ can be computed by model $X$ using $s$ operations".
 
@@ -135,11 +135,11 @@ $$OR(a,b) = \begin{cases} 0 & a=b=0 \\ 1 & \text{otherwise} \end{cases}$$
 
 $$AND(a,b) = \begin{cases} 1 & a=b=1 \\ 0 & \text{otherwise} \end{cases}$$
 
-* $NOT:\{0,1\} \rightarrow \{0,1\}$ defined as 
+* $NOT:\{0,1\} \rightarrow \{0,1\}$ defined as
 
 $$NOT(a) = \begin{cases} 0 & a = 1 \\ 1 & a = 0 \end{cases}$$
 
-The functions $AND$, $OR$ and $NOT$, are the basic logical operators used in logic and many computer system.
+The functions $AND$, $OR$ and $NOT$, are the basic logical operators used in logic and many computer systems.
 In the context of logic, it is common to use the notation $a \wedge b$ for $AND(a,b)$, $a \vee b$ for $OR(a,b)$ and $\overline{a}$ and $\neg a$ for $NOT(a)$, and we will use this notation as well.
 
 Each one of the functions $AND,OR,NOT$ takes either one or two single bits as input, and produces a single bit as output.
@@ -214,20 +214,20 @@ As usual, it is a good exercise to try to work out the algorithm for $XOR$ using
 :::
 
 
-The following algorithm computes $XOR$ using $AND$, $OR$, and $NOT$: 
+The following algorithm computes $XOR$ using $AND$, $OR$, and $NOT$:
 
 
 ``` {.algorithm title="$XOR$ from $AND$/$OR$/$NOT$" #XORfromAONalg}
 Input: $a,b \in \{0,1\}$.
 Output: $XOR(a,b)$
 
-$w1 \leftarrow AND(a,b)$ 
+$w1 \leftarrow AND(a,b)$
 
-$w2 \leftarrow NOT(w1)$ 
+$w2 \leftarrow NOT(w1)$
 
-$w3 \leftarrow OR(a,b)$ 
+$w3 \leftarrow OR(a,b)$
 
-return $AND(w2,w3)$ 
+return $AND(w2,w3)$
 ```
 
 
@@ -356,7 +356,7 @@ We will also discuss how to _physically implement_ simple operations such as $AN
 ![Standard symbols for the logical operations or "gates" of $AND$, $OR$, $NOT$, as well as the operation $NAND$ discussed in [nandsec](){.ref}.](../figure/logicgates.png){#logicgatesfig .margin }
 
 
-![A circuit with $AND$, $OR$ and $NOT$ gates  for computing the $XOR$ function.](../figure/xorcircuitschemdraw.png){#andornotcircxorfig  .margin  } 
+![A circuit with $AND$, $OR$ and $NOT$ gates  for computing the $XOR$ function.](../figure/xorcircuitschemdraw.png){#andornotcircxorfig  .margin  }
 
 
 
@@ -434,7 +434,7 @@ Let $n,m,s$ be positive integers with $s \geq m$. A _Boolean circuit_ with $n$ i
 
 * Exactly $n$ of the vertices have no in-neighbors. These vertices are known as _inputs_ and are labeled with the $n$ labels `X[`$0$`]`, $\ldots$, `X[`$n-1$`]`.
 
-* The other $s$ vertices are known as _gates_. Each gate is labeled with $\wedge$, $\vee$ or $\neg$. Gates labeled with $\wedge$ (_AND_) or $\vee$ (_OR_) have two in-neighbors. Gates labeled with $\neg$ (_NOT_) have one in-neighbor. We will allow parallel edges.^[Having parallel edges means an AND or OR gate $u$ can have both its in-neighbors be the same gate $v$. Since $AND(a,a)=OR(a,a)=a$ for every $a\in \{0,1\}$, such parallel edges don't help in computing new values in circuits with AND/OR/NOT gates. However, we will see circuits with more general sets of gates later on.] 
+* The other $s$ vertices are known as _gates_. Each gate is labeled with $\wedge$, $\vee$ or $\neg$. Gates labeled with $\wedge$ (_AND_) or $\vee$ (_OR_) have two in-neighbors. Gates labeled with $\neg$ (_NOT_) have one in-neighbor. We will allow parallel edges.^[Having parallel edges means an AND or OR gate $u$ can have both its in-neighbors be the same gate $v$. Since $AND(a,a)=OR(a,a)=a$ for every $a\in \{0,1\}$, such parallel edges don't help in computing new values in circuits with AND/OR/NOT gates. However, we will see circuits with more general sets of gates later on.]
 * Exactly $m$ of the gates are also labeled with the $m$ labels   `Y[`$0$`]`, $\ldots$, `Y[`$m-1$`]` (in addition to their label $\wedge$/$\vee$/$\neg$). These are known as _outputs_.
 :::
 
@@ -511,7 +511,7 @@ The number represented by $(a,b)$ is larger than the number represented by $(c,d
 
 1. The most significant bit $a$ of $(a,b)$   is larger than the most significant bit $c$ of $(c,d)$.
 
-or 
+or
 
 2. The two most significant bits $a$ and $c$ are equal, but $b>d$.
 
@@ -555,7 +555,7 @@ For example, an _AND_ gate in a Boolean circuit corresponding to computing the _
 In a AON-CIRC program this will correspond to the line that stores in a variable the `AND` of two previously-computed variables.
 
 ::: { .pause }
-This proof of [slcircuitequivthm](){.ref} is simple at heart, but all the details it contains can make it a little cumbersome to read. You might be better off trying to work it out yourself before reading it. 
+This proof of [slcircuitequivthm](){.ref} is simple at heart, but all the details it contains can make it a little cumbersome to read. You might be better off trying to work it out yourself before reading it.
 Our  [GitHub repository](https://github.com/boazbk/tcscode)  contains a  "proof by Python" of [slcircuitequivthm](){.ref}: implementation of functions `circuit2prog` and `prog2circuits` mapping Boolean circuits to AON-CIRC programs
 and vice versa.
 :::
@@ -582,7 +582,7 @@ Once again, one can verify that for every input $x$, the value $P(x)$ will equal
 
 
 ## Physical implementations of computing devices (digression) {#physicalimplementationsec }
- 
+
 
 _Computation_ is an abstract notion that is distinct from its physical _implementations_.
 While most modern computing devices are obtained by mapping logical gates to semi-conductor based transistors, over history people have computed using a huge variety of mechanisms,  including mechanical systems, gas and liquid (known as _fluidics_), biological and chemical processes, and even living creatures (e.g., see [crabfig](){.ref} or  [this video](https://www.youtube.com/watch?v=czk4xgdhdY4) for how crabs or slime mold can be used to do computations).
@@ -655,7 +655,7 @@ Even larger systems such as [flocks of birds](https://www.cs.princeton.edu/~chaz
 
 _Cellular automata_ is a model of a system composed of a sequence of _cells_, which of which can have a finite state.
 At each step, a cell updates its state based on the states of its _neighboring cells_ and some simple rules.
-As we will discuss later in this book (see [cellularautomatasec](){.ref}), cellular automata such as Conway's "Game of Life" can be used to simulate computation gates . 
+As we will discuss later in this book (see [cellularautomatasec](){.ref}), cellular automata such as Conway's "Game of Life" can be used to simulate computation gates .
 
 ![An AND gate using a "Game of Life" configuration. Figure taken from [Jean-Philippe Rennard's paper](http://www.rennard.org/alife/CollisionBasedRennard.pdf).](../figure/game_of_life_and.png){#gameoflifefig .margin  }
 
@@ -829,9 +829,9 @@ Let $c_0 \leftarrow 1$ # we pretend we have a "carry" of $1$ initially
 For{$i=0,\ldots, n-1$}
 Let $y_i \leftarrow XOR(x_i,c_i)$.
 If{$c_i=x_i=1$}
-$c_{i+1}=1$ 
+$c_{i+1}=1$
 else
-$c_{i+1}=0$ 
+$c_{i+1}=0$
 endif
 Endfor
 Let $y_n \leftarrow c_n$.
@@ -849,7 +849,7 @@ For example, [nandincrememntcircfig](){.ref} shows how this circuit looks like f
 
 
 
-![NAND circuit with computing the _increment_ function on $4$ bits.](../figure/incrementfromnand.png){#nandincrememntcircfig  .margin } 
+![NAND circuit with computing the _increment_ function on $4$ bits.](../figure/incrementfromnand.png){#nandincrememntcircfig  .margin }
 
 
 
@@ -868,8 +868,8 @@ Let $c_0 \leftarrow 0$
 For{$i=0,\ldots,n-1$}
     Let $y_i \leftarrow u_i + v_i \mod 2$
     If{$u_i + v_i + c_i \geq 2$}
-    $c_{i+1}\leftarrow 1$ 
-    else 
+    $c_{i+1}\leftarrow 1$
+    else
     $c_{i+1} \leftarrow 0$
     endif
 Endfor
@@ -878,7 +878,7 @@ Let $y_n \leftarrow c_n$
 
 
 Once again, [additionfromnand](){.ref} can be translated into a NAND circuit.
-The crucial observation is that the "if/then" statement simply corresponds to 
+The crucial observation is that the "if/then" statement simply corresponds to
 $c_{i+1} \leftarrow MAJ_3(u_i,v_i,v_i)$ and we have seen in in [majbynandex](){.ref} that the function $MAJ_3:\{0,1\}^3 \rightarrow \{0,1\}$ can be computed using $NAND$s.
 
 
@@ -896,12 +896,12 @@ foo = NAND(bar,blah)
 where `foo`, `bar` and `blah` are variable identifiers.
 
 ::: {.example title="Our first NAND-CIRC program" #NANDprogramexample}
-Here is an example of a NAND-CIRC program: 
+Here is an example of a NAND-CIRC program:
 
 ```python
 u = NAND(X[0],X[1])
 v = NAND(X[0],u)
-w = NAND(X[1],u) 
+w = NAND(X[1],u)
 Y[0] = NAND(v,w)
 ```
 :::
@@ -934,7 +934,7 @@ For every $f:\{0,1\}^n \rightarrow \{0,1\}^m$ and $s \geq m$, $f$ is computable 
 We omit the proof of [NANDcircslequivthm](){.ref} since it follows along exactly the same lines as the equivalence of Boolean circuits and AON-CIRC program  ([slcircuitequivthm](){.ref}).
 Given [NANDcircslequivthm](){.ref} and [NANDuniversamthm](){.ref}, we know that we can translate every $s$-line AON-CIRC program $P$ into an equivalent NAND-CIRC program of at most $3s$ lines.
 In fact, this translation can be easily done by replacing every line of the form `foo = AND(bar,blah)`, `foo = OR(bar,blah)` or `foo = NOT(bar)` with the equivalent 1-3 lines that use the `NAND` operation.
-Our [GitHub repository](https://github.com/boazbk/tcscode) contains a "proof by code": a simple Python program `AON2NAND` that transforms an AON-CIRC into an equivalent NAND-CIRC program. 
+Our [GitHub repository](https://github.com/boazbk/tcscode) contains a "proof by code": a simple Python program `AON2NAND` that transforms an AON-CIRC into an equivalent NAND-CIRC program.
 
 
 
@@ -1102,7 +1102,7 @@ if $B$ is universal then there is a $B$-circuit of at most $O(k)$ gates to compu
 Prove that there is some constant $c$ such that for every $n>1$, and integers $a_0,\ldots,a_{n-1},b \in \{-2^n,-2^n+1,\ldots,-1,0,+1,\ldots,2^n\}$, there is a NAND circuit with at most $c\dot n^4$ gates that computes the _threshold_ function $f_{a_0,\ldots,a_{n-1},b}:\{0,1\}^n \rightarrow \{0,1\}$ that on input $x\in \{0,1\}^n$ outputs $1$ if and only if $\sum_{i=0}^{n-1} a_i x_i > b$.
 
 ::: {.exercise title="NANDs from activation functions" #NANDsfromActivationfunctionex}
-We say that a function $f:\mathbb{R}^2 \rightarrow \mathbb{R}$ is a _NAND approximator_ if it has 
+We say that a function $f:\mathbb{R}^2 \rightarrow \mathbb{R}$ is a _NAND approximator_ if it has
 the following property: for every $a,b \in \mathbb{R}$, if $\min\{|a|,|1-a|\}\leq 1/3$ and $\min \{ |b|,|1-b| \}\leq 1/3$ then $|f(a,b) - NAND(\lfloor a \rceil, lfloor b \rceil)| \leq 1/3$ where we denote by $\lfloor x \rfloor$ the integer closest to $x$.
 That is, if $a,b$ are within a distance $1/3$ to $\{0,1\}$ then we want $f(a,b)$ to equal the $NAND$ of the values in $\{0,1\}$ that are closest to $a$ and $b$ respectively. Otherwise, we do not care what the output of $f$ is on $a$ and $b$.
 

--- a/lec_03a_computing_every_function.md
+++ b/lec_03a_computing_every_function.md
@@ -740,7 +740,7 @@ On the other hand, if $f$ can be computed by a Boolean AND/OR/NOT circuit of at 
 
 The results we have seen in this chapter can be phrased as showing that $ADD_n \in SIZE_{2n,n+1}(100 n)$
 and $MULT_n \in SIZE_{2n,2n}(10000 n^{\log_2 3})$.
-[NAND-univ-thm](){.ref} shows that  for some constant $c$, $SIZE_{n,m}(c m 2^n)$ is equal the set of all functions from $\{0,1\}^n$ to $\{0,1\}^m$.
+[NAND-univ-thm](){.ref} shows that  for some constant $c$, $SIZE_{n,m}(c m 2^n)$ is equal to the set of all functions from $\{0,1\}^n$ to $\{0,1\}^m$.
 
 
 

--- a/lec_03a_computing_every_function.md
+++ b/lec_03a_computing_every_function.md
@@ -70,7 +70,7 @@ Enumerating the examples of such  syntactic sugar transformations can be a littl
 ### User-defined procedures
 
 One staple of almost any programming language is the ability to define and then execute _procedures_ or _subroutines_.
-(These are often  known as _functions_ in some programming languages, but we prefer the name _procedures_ 
+(These are often  known as _functions_ in some programming languages, but we prefer the name _procedures_
 to avoid confusion with the function that a program computes.)
 The NAND-CIRC programming language does not have this mechanism built in.
 However, we can achieve the same effect using the time honored technique of  "copy and paste".
@@ -117,14 +117,14 @@ Procedures allow us to express NAND-CIRC programs much more cleanly and succinct
 For example, because we can compute AND, OR, and NOT using NANDs, we can compute the _Majority_ function as follows:
 
 ```python
-def NOT(a): 
+def NOT(a):
     return NAND(a,a)
 def AND(a,b):
-    temp = NAND(a,b) 
+    temp = NAND(a,b)
     return NOT(temp)
 def OR(a,b):
     temp1 = NOT(a)
-    temp2 = NOT(b) 
+    temp2 = NOT(b)
     return NAND(temp1,temp2)
 
 def MAJ(a,b,c):
@@ -181,10 +181,10 @@ The code in [desugarcode](){.ref} achieves such a  transformation.^[This code us
 
 ``` { .python  #desugarcode title="Python code for transforming NAND-CIRC-PROC programs into standard sugar free NAND-CIRC programs." }
 def inline_proc(code, proc_name, proc_args,proc_body):
-    '''Takes code of a program and name, arguments, body of a procedure. 
-    Returns new code where all lines in program of the 
-    form "foo = proc_name(bar,blah,..)" are replaced with 
-    the body of the procedure with  arguments instantiated 
+    '''Takes code of a program and name, arguments, body of a procedure.
+    Returns new code where all lines in program of the
+    form "foo = proc_name(bar,blah,..)" are replaced with
+    the body of the procedure with  arguments instantiated
     with the variables bar, blah, etc.'''
     arglist = ",".join([r"([a-zA-Z0-9\_\[\]]+)" for i in range(len(proc_args))])
     regexp = fr'([a-zA-Z0-9\_\[\]]+)\s*=\s*{proc_name}\({arglist}\)\s*$'
@@ -192,8 +192,8 @@ def inline_proc(code, proc_name, proc_args,proc_body):
     while True:
         m = re.search(regexp, code, re.MULTILINE)
         if not m: break
-        newcode = proc_body 
-        for i in range(len(proc_args)): 
+        newcode = proc_body
+        for i in range(len(proc_args)):
             newcode = newcode.replace(proc_args[i], m.group(i+2))
         newcode = newcode.replace('return', m.group(1) + " = ")
         code = code[:m.start()] + newcode + code[m.end()+1:]
@@ -219,7 +219,7 @@ def parse_procs(code):
     rest = ""
     while current_line < len(lines):
         m = re.match(regexp,lines[current_line])
-        if m: 
+        if m:
             current_line+= 1
             code = ""
             while current_line < len(lines) and lines[current_line][0]==' ':
@@ -352,14 +352,14 @@ Once we have addition, we can use the grade-school algorithm to obtain multiplic
 For every $n$, let $MULT_n:\{0,1\}^{2n}\rightarrow \{0,1\}^{2n}$ be the function that, given $x,x'\in \{0,1\}^n$ computes the representation of the product of the numbers that $x$ and $x'$ represent. Then there is a constant $c$ such that for every $n$, there is a NAND-CIRC program of at most $cn^2$ that computes the function $MULT_n$.
 
 We omit the proof, though in [multiplication-ex](){.ref} we ask you to supply a "constructive proof" in the form of a program (in your favorite programming language) that on input a number $n$, outputs the code of a NAND-CIRC program of at most $1000n^2$ lines that computes the $MULT_n$ function.
-In fact, we can use Karatsuba's algorithm to show that there is a NAND-CIRC program of $O(n^{\log_2 3})$ lines to compute $MULT_n$ 
+In fact, we can use Karatsuba's algorithm to show that there is a NAND-CIRC program of $O(n^{\log_2 3})$ lines to compute $MULT_n$
 (and can get even further asymptotic improvements using better algorithms).
 
 
 ## The LOOKUP function { #seclookupfunc }
 
 The $LOOKUP$ function  will play an important role in this chapter and later.
-It is defined as follows: 
+It is defined as follows:
 
 
 > ### {.definition title="Lookup function" #lookup-def}
@@ -387,7 +387,7 @@ An immediate corollary of [lookup-thm](){.ref} is that for every $k>0$, $LOOKUP_
 
 We  prove [lookup-thm](){.ref} by induction.
 For the case $k=1$, $LOOKUP_1$  maps $(x_0,x_1,i) \in \{0,1\}^3$ to $x_i$.
-In other words, if $i=0$ then it outputs $x_0$ and otherwise it outputs $x_1$, which (up to reordering variables) is the same as 
+In other words, if $i=0$ then it outputs $x_0$ and otherwise it outputs $x_1$, which (up to reordering variables) is the same as
 the $IF$ function presented in  [ifstatementsec](){.ref}, which can be computed by a 4-line NAND-CIRC program.
 
 As a warm-up for the case of general $k$,  let us consider the case of $k=2$.
@@ -428,7 +428,7 @@ Thus we can compute $LOOKUP_k(x,i)$ by first computing $a$ and $b$ and then outp
 
 
 __Proof of [lookup-thm](){.ref} from [lookup-rec-lem](){.ref}.__ Now that we have [lookup-rec-lem](){.ref},
-we can complete the proof of [lookup-thm](){.ref}. 
+we can complete the proof of [lookup-thm](){.ref}.
 We will prove by induction on $k$ that there is a NAND-CIRC program of at most $4\cdot 2^k$ lines for $LOOKUP_k$.
 For $k=1$ this follows by the four line program for $IF$ we've seen before.
 For $k>1$, we use the following pseudocode
@@ -479,10 +479,10 @@ _Every_ finite function can be computed by a large enough Boolean circuit.
 
 
 
-_Improved bounds._ Though it will not be of great importance to us, it is possible to improve on the proof of 
-[NAND-univ-thm](){.ref}  and shave an extra factor of $n$, as well as optimize the constant $c$, and so prove that 
+_Improved bounds._ Though it will not be of great importance to us, it is possible to improve on the proof of
+[NAND-univ-thm](){.ref}  and shave an extra factor of $n$, as well as optimize the constant $c$, and so prove that
 for every $\epsilon>0$, $m\in \N$ and sufficiently large $n$, if $f:\{0,1\}^n \rightarrow \{0,1\}^m$ then $f$ can be computed by a NAND circuit of at most
-$(1+\epsilon)\tfrac{m\cdot 2^n}{n}$ gates. 
+$(1+\epsilon)\tfrac{m\cdot 2^n}{n}$ gates.
 The proof of this result is beyond the scope of this book, but we do discuss how to obtain a bound of the form $O(\tfrac{m \cdot 2^n}{n})$ in [tight-upper-bound](){.ref}; see also the biographical notes.
 
 
@@ -586,9 +586,9 @@ $$
 ![We can compute $f:\{0,1\}^n \rightarrow \{0,1\}$ on input $x=ab$ where $a\in \{0,1\}^k$ and $b\in \{0,1\}^{n-k}$ by first computing the $2^{n-k}$ long string $g(a)$  that corresponds to all $f$'s values on inputs that begin with $a$, and then outputting the $b$-th coordinate of this string.](../figure/efficient_circuit_allfunc.png){#efficient_circuit_allfuncfig .margin}
 
 
-[eqcomputefusinggeffcircuit](){.eqref} means that for every $x\in \{0,1\}^n$, if we write 
-$x=ab$ with $a\in \{0,1\}^k$ and $b\in \{0,1\}^{n-k}$ then we can compute $f(x)$ by 
-first computing the string  $T=g(a)$  of length $2^{n-k}$, and then computing $LOOKUP_{n-k}(T\;,\; b)$ to retrieve the 
+[eqcomputefusinggeffcircuit](){.eqref} means that for every $x\in \{0,1\}^n$, if we write
+$x=ab$ with $a\in \{0,1\}^k$ and $b\in \{0,1\}^{n-k}$ then we can compute $f(x)$ by
+first computing the string  $T=g(a)$  of length $2^{n-k}$, and then computing $LOOKUP_{n-k}(T\;,\; b)$ to retrieve the
 element of $T$ at the position corresponding to $b$ (see [efficient_circuit_allfuncfig](){.ref}).
 The cost to compute the $LOOKUP_{n-k}$ is $O(2^{n-k})$ lines/gates and the cost in NAND-CIRC lines (or Boolean gates) to compute  $f$ is at most
 $$
@@ -597,13 +597,13 @@ $$
 where $cost(g)$ is the number of operations (i.e., lines of NAND-CIRC programs or gates in a circuit) needed to compute $g$.
 
 
-To complete the proof we need to give a  bound on  $cost(g)$. 
+To complete the proof we need to give a  bound on  $cost(g)$.
 Since $g$ is a function mapping $\{0,1\}^k$ to $\{0,1\}^{2^{n-k}}$, we can also think of it as a
 collection of $2^{n-k}$ functions $g_0,\ldots, g_{2^{n-k}-1}: \{0,1\}^k \rightarrow \{0,1\}$, where
 $g_i(x) = g(a)_i$ for every $a\in \{0,1\}^k$ and $i\in [2^{n-k}]$. (That is, $g_i(a)$ is the $i$-th bit of $g(a)$.)
 Naively, we could use  [NAND-univ-thm](){.ref}  to compute each $g_i$ in $O(2^k)$ lines, but then
 the total cost is $O(2^{n-k} \cdot 2^k) = O(2^n)$ which does not save us anything.
-However, the crucial observation is that there are only $2^{2^k}$ _distinct functions_ mapping 
+However, the crucial observation is that there are only $2^{2^k}$ _distinct functions_ mapping
 $\{0,1\}^k$ to $\{0,1\}$.
 For example, if $g_{17}$ is an identical function to $g_{67}$ that means that if we already computed $g_{17}(a)$ then we can compute $g_{67}(a)$ using only a constant number of operations: simply copy the same value!
 In general, if you have a collection of $N$ functions $g_0,\ldots,g_{N-1}$ mapping $\{0,1\}^k$ to $\{0,1\}$, of which at most $S$ are distinct then for every value $a\in \{0,1\}^k$ we can compute the $N$ values $g_0(a),\ldots,g_{N-1}(a)$ using at most $O(S\cdot 2^k + N)$ operations (see [computemanyfunctionsfig](){.ref}).
@@ -613,7 +613,7 @@ In general, if you have a collection of $N$ functions $g_0,\ldots,g_{N-1}$ mappi
 ![If $g_0,\ldots, g_{N-1}$ is a collection of functions each mapping $\{0,1\}^k$ to $\{0,1\}$ such that at most $S$ of them are distinct then for every $a\in \{0,1\}^k$, we can compute all the values $g_0(a),\ldots,g_{N-1}(a)$ using at most $O(S \cdot 2^k + N)$ operations by first computing the distinct functions and then copying the resulting values.](../figure/computemanyfunctions.png){#computemanyfunctionsfig .margin }
 
 In our case, because there are at most $2^{2^k}$ distinct functions mapping $\{0,1\}^k$ to $\{0,1\}$, we can compute the function $g$ (and hence by [eqcomputefusinggeffcircuit](){.eqref}  also $f$) using at most  
-$$O(2^{2^k} \cdot 2^k + 2^{n-k}) \label{eqboundoncostg}$$ 
+$$O(2^{2^k} \cdot 2^k + 2^{n-k}) \label{eqboundoncostg}$$
 operations.
 Now all that is left is to plug  into [eqboundoncostg](){.eqref} our choice of $k = \log (n-2\log n)$.
 By definition, $2^k = n-2\log n$, which means that   [eqboundoncostg](){.eqref} can be bounded
@@ -622,9 +622,9 @@ O\left(2^{n-2\log n} \cdot (n-2\log n) +  2^{n-\log(n-2\log n)}\right) \leq
 $$
 
 $$
-O\left(\tfrac{2^n}{n^2} \cdot n + \tfrac{2^n}{n-2\log n} \right) 
+O\left(\tfrac{2^n}{n^2} \cdot n + \tfrac{2^n}{n-2\log n} \right)
 \leq
-O\left(\tfrac{2^n}{n}  + \tfrac{2^n}{0.5n} \right)  = O\left( \tfrac{2^n}{n} \right) 
+O\left(\tfrac{2^n}{n}  + \tfrac{2^n}{0.5n} \right)  = O\left( \tfrac{2^n}{n} \right)
 $$
 which is what we wanted to prove. (We used above the fact that $n - 2\log n \geq 0.5 \log n$ for sufficiently large $n$.)
 :::
@@ -639,7 +639,7 @@ There exists some constant $c>0$ such that for every $n,m>0$ and function $f: \{
 
 [circuit-univ-thm](){.ref} is a fundamental result in the theory (and practice!) of computation.
 In this section we present an alternative proof of this basic fact that Boolean circuits can compute every finite function.
-This alternative proof gives somewhat worse quantitative bound on the number of gates but it has the advantage of being simpler, working directly with circuits and avoiding the usage of all the syntactic sugar machinery.
+This alternative proof gives a somewhat worse quantitative bound on the number of gates but it has the advantage of being simpler, working directly with circuits and avoiding the usage of all the syntactic sugar machinery.
 (However, that machinery is useful in its own right, and will find other applications later on.)
 
 
@@ -652,7 +652,7 @@ There exists some constant $c>0$ such that for every $n,m>0$ and function $f: \{
 
 > ### {.proofidea data-ref="circuit-univ-alt-thm"}
 The idea of the proof is illustrated in [computeallfuncaltfig](){.ref}. As before, it is enough to focus on the case that $m=1$ (the function $f$ has a single output), since we can always extend this to the case of $m>1$ by looking at the composition of $m$ circuits each computing a different output bit of the function $f$.
-We start by showing that for every $\alpha \in \{0,1\}^n$, there is an $O(n)$ sized circuit that computes the function $\delta_\alpha:\{0,1\}^n \rightarrow \{0,1\}$ defined as follows: $\delta_\alpha(x)=1$ iff $x=\alpha$ (that is, $\delta_\alpha$ outputs $0$ on all inputs except the input $\alpha$). We can then write any function $f:\{0,1\}^n \rightarrow \{0,1\}$ as the OR of at most $2^n$ functions $\delta_\alpha$ for the $\alpha$'s on which $f(\alpha)=1$. 
+We start by showing that for every $\alpha \in \{0,1\}^n$, there is an $O(n)$ sized circuit that computes the function $\delta_\alpha:\{0,1\}^n \rightarrow \{0,1\}$ defined as follows: $\delta_\alpha(x)=1$ iff $x=\alpha$ (that is, $\delta_\alpha$ outputs $0$ on all inputs except the input $\alpha$). We can then write any function $f:\{0,1\}^n \rightarrow \{0,1\}$ as the OR of at most $2^n$ functions $\delta_\alpha$ for the $\alpha$'s on which $f(\alpha)=1$.
 
 ::: {.proof data-ref="circuit-univ-alt-thm"}
 We prove the theorem for the case $m=1$. The result can be extended for $m>1$ as before (see also [mult-bit-ex](){.ref}).
@@ -674,10 +674,10 @@ then there is a Boolean circuit using at most $2n$ gates that computes $\delta_\
 __PROOF OF CLAIM:__ The proof is illustrated in [deltafuncfig](){.ref}.
 As an example, consider the function $\delta_{011}:\{0,1\}^3 \rightarrow \{0,1\}$.
 This function outputs $1$ on $x$ if and only if $x_0=0$, $x_1=1$ and $x_2=1$, and so we can write $\delta_{011}(x) = \overline{x_0} \wedge x_1 \wedge x_2$, which translates into a Boolean circuit with one NOT gate and two AND gates.
-More generally, for every $\alpha \in \{0,1\}^n$, we can express $\delta_{\alpha}(x)$  as $(x_0 = \alpha_0) \wedge (x_1 = \alpha_1) \wedge \cdots \wedge (x_{n-1} = \alpha_{n-1})$, where if $\alpha_i=0$ we replace $x_i = \alpha_i$ with $\overline{x_i}$ and if $\alpha_i=1$ we replace $x_i=\alpha_i$ by simply $x_i$. 
+More generally, for every $\alpha \in \{0,1\}^n$, we can express $\delta_{\alpha}(x)$  as $(x_0 = \alpha_0) \wedge (x_1 = \alpha_1) \wedge \cdots \wedge (x_{n-1} = \alpha_{n-1})$, where if $\alpha_i=0$ we replace $x_i = \alpha_i$ with $\overline{x_i}$ and if $\alpha_i=1$ we replace $x_i=\alpha_i$ by simply $x_i$.
 This yields a circuit that computes $\delta_\alpha$ using $n$ AND gates and at most $n$ NOT gates, so a total of at most $2n$ gates.
 
-Now for every function $f:\{0,1\}^n \rightarrow \{0,1\}$, we can write 
+Now for every function $f:\{0,1\}^n \rightarrow \{0,1\}$, we can write
 
 $$
 f(x) = \delta_{x_0}(x) \vee \delta_{x_1}(x) \vee \cdots \vee \delta_{x_{N-1}}(x) \label{eqorofdeltafunc}
@@ -704,7 +704,7 @@ Formally, the definition is as follows:
 
 > ### {.definition title="Size class of functions" #sizedef}
 For every integer $s \geq 1$, we let $SIZE(s)$ be the set of all functions $f$ for which there exists a NAND circuit of at most $s$ gates that compute $f$.
-For every $n,m  \in \{ 1, \ldots , 2s\}$, we let set $SIZE_{n,m}(s)$ denotes the set of all functions $f:\{0,1\}^n \rightarrow \{0,1\}^m$ such that $f\in SIZE(s)$.^[The restriction that $m,n \leq 2s$ makes no difference; see [nandcircsizeex](){.ref}.] 
+For every $n,m  \in \{ 1, \ldots , 2s\}$, we let set $SIZE_{n,m}(s)$ denotes the set of all functions $f:\{0,1\}^n \rightarrow \{0,1\}^m$ such that $f\in SIZE(s)$.^[The restriction that $m,n \leq 2s$ makes no difference; see [nandcircsizeex](){.ref}.]
 We denote by $SIZE_n(s)$ the set $SIZE_{n,1}(s)$.
 
 [funcvscircfig](){.ref} depicts the sets $SIZE_{n,1}(s)$.
@@ -814,7 +814,7 @@ where $MAJ(a,b,c) = 1$ iff $a+b+c \geq 2$.
 ::: {.exercise title="Conditional statements" #conditionalsugarthmex}
 In this exercise we will explore [conditionalsugarthm](){.ref}: transforming NAND-CIRC-IF programs that use code such as `if .. then .. else ..` to standard NAND-CIRC programs.
 
-1. Give a "proof by code" of [conditionalsugarthm](){.ref}: a program in a programming language of your choice that transforms a NAND-CIRC-IF program $P$ into a "sugar free" NAND-CIRC program $P'$ that computes the same function. See footnote for hint.^[You can start by transforming $P$ into a NAND-CIRC-PROC program that uses procedure statements, and then use the code of [desugarcode](){.ref} to transform the latter into a "sugar free" NAND-CIRC program.] 
+1. Give a "proof by code" of [conditionalsugarthm](){.ref}: a program in a programming language of your choice that transforms a NAND-CIRC-IF program $P$ into a "sugar free" NAND-CIRC program $P'$ that computes the same function. See footnote for hint.^[You can start by transforming $P$ into a NAND-CIRC-PROC program that uses procedure statements, and then use the code of [desugarcode](){.ref} to transform the latter into a "sugar free" NAND-CIRC program.]
 
 2. Prove the following statement, which is the heart of  [conditionalsugarthm](){.ref}: suppose that there exists an $s$-line NAND-CIRC program to compute $f:\{0,1\}^n \rightarrow \{0,1\}$ and an $s'$-line NAND-CIRC program to compute $g:\{0,1\}^n \rightarrow \{0,1\}$.
 Prove that there exist a NAND-CIRC program of at most $s+s'+10$ lines to compute the function $h:\{0,1\}^{n+1} \rightarrow \{0,1\}$ where $h(x_0,\ldots,x_{n-1},x_n)$ equals $f(x_0,\ldots,x_{n-1})$ if $x_n=0$ and equals $g(x_0,\ldots,x_{n-1})$ otherwise. (All programs in this item are standard "sugar-free" NAND-CIRC programs.)
@@ -915,6 +915,3 @@ Shannon showed that every Boolean function can be computed by a circuit of expon
 (Thanks to Sasha Golovnev for tracking down this reference!)
 
 The concept of "syntactic sugar" is also known as "macros" or "meta-programming" and is sometimes implemented via a preprocessor or macro language in a programming language or a text editor. One modern example is the [Babel](https://babeljs.io/) JavaScript syntax transformer, that converts JavaScript programs written using the latest features into a format that older Browsers can accept. It even has a [plug-in](https://babeljs.io/docs/plugins/) architecture, that allows users to add their own syntactic sugar to the language.
-
-
-

--- a/lec_03a_computing_every_function.md
+++ b/lec_03a_computing_every_function.md
@@ -735,7 +735,7 @@ On the other hand, if $f$ can be computed by a Boolean AND/OR/NOT circuit of at 
 
 
 
-![A "category error" is a question such as "is a cucumber even or odd?" which does not even make sense. In this book one type of category errors you should watch out for is confusing _functions_ and _programs_ (i.e., confusing _specifications_ and _implementations_). If $C$ is a circuit or program, then asking if $C \in SIZE_{n,1}(s)$ is a category error, since $SIZE_{n,1}(s)$ is a set of _functions_ and not programs or circuits.](../figure/cucumber.png){#cucumberfig .margin  }
+![A "category error" is a question such as "is a cucumber even or odd?" which does not even make sense. In this book one type of category error you should watch out for is confusing _functions_ and _programs_ (i.e., confusing _specifications_ and _implementations_). If $C$ is a circuit or program, then asking if $C \in SIZE_{n,1}(s)$ is a category error, since $SIZE_{n,1}(s)$ is a set of _functions_ and not programs or circuits.](../figure/cucumber.png){#cucumberfig .margin  }
 
 
 The results we have seen in this chapter can be phrased as showing that $ADD_n \in SIZE_{2n,n+1}(100 n)$

--- a/lec_04_code_and_data.md
+++ b/lec_04_code_and_data.md
@@ -71,7 +71,7 @@ See [codedataoverviewfig](){.ref} for an overview of the results of  this chapte
 
 ![In the Harvard Mark I computer, a program was represented as a list of triples of numbers, which were then encoded by perforating holes in a control card.](../figure/tapemarkI.png){#markonerep .margin  }
 
-We can represents programs or circuits as strings in a myriad of ways.
+We can represent programs or circuits as strings in a myriad of ways.
 For example, since Boolean circuits are labeled directed acyclic graphs, we can use the _adjacency matrix_ or _adjacency list_ representations for them.
 However, since the code of a program is ultimately just a sequence of letters and symbols, arguably the conceptually simplest representation of a program is as such a sequence.
 For example,  the following NAND-CIRC program $P$
@@ -79,7 +79,7 @@ For example,  the following NAND-CIRC program $P$
 ```python
 temp_0 = NAND(X[0],X[1])
 temp_1 = NAND(X[0],temp_0)
-temp_2 = NAND(X[1],temp_0) 
+temp_2 = NAND(X[1],temp_0)
 Y[0] = NAND(temp_1,temp_2)
 ```
 
@@ -104,7 +104,7 @@ There is a constant $c$ such that for $f \in SIZE(s)$, there exists a program $P
 :::
 
 ::: { .pause }
-We omit the formal proof of [asciirepprogramthm](){.ref} but please make sure that you understand why it follows from the reasoning above. 
+We omit the formal proof of [asciirepprogramthm](){.ref} but please make sure that you understand why it follows from the reasoning above.
 :::
 
 
@@ -117,7 +117,7 @@ This has consequences for the sets $SIZE(s)$ that we defined in [secdefinesizecl
 
 
 > ### {.theorem title="Counting programs" #program-count}
-For every $s\in \N$, 
+For every $s\in \N$,
 $$|SIZE(s)| \leq 2^{O(s \log s)}.$$
 That is, there are at most $2^{O(s\log s)}$ functions computed by NAND-CIRC programs of at most $s$ lines.^[The implicit constant in the $O(\cdot)$ notation is smaller than $10$. That is, for all sufficiently large $s$, $|SIZE(s)|<  2^{10s\log s}$, see [efficientrepresentation](){.ref}. As discussed in [[notationsec](){.ref}](){.ref}, we use the bound $10$ simply because it is a round number. ]
 
@@ -205,7 +205,7 @@ Let $f^*: \{0,1\}^n \rightarrow \{0,1\}$ be the function (whose existence we are
 We define the functions $f_0,f_1,\ldots, f_{2^n}$ mapping $\{0,1\}^n$ to $\{0,1\}$ as follows. For every $x\in \{0,1\}^n$, if $lex(x) \in \{0,1,\ldots, 2^n-1\}$ is $x$'s order
 in the lexicographical order then
 $$
-f_i(x) = \begin{cases} f^*(x) & lex(x)< i  \\ 0 & \text{otherwise} \end{cases} \;. 
+f_i(x) = \begin{cases} f^*(x) & lex(x)< i  \\ 0 & \text{otherwise} \end{cases} \;.
 $$
 
 The function $f_0$ is simply the constant zero function, while the function $f_{2^n}$ is equal to $f^*$.
@@ -213,7 +213,7 @@ Moreover, for every $i\in [2^n]$, the function $f_i$ and $f_{i+1}$ differ on at 
 Let $10n < s < 0.1 \cdot 2^n /n$, and let $i$ be the first index such that $f_i \not\in SIZE_n(s)$.
 Since $f_{2^n} = f^* \not\in SIZE(0.1 \dot 2^n / n)$ there must exist such an index $i$, and moreover $i>0$ since the constant zero function is a member of $SIZE_n(10n)$.
 
-By our choice of $i$, $f_{i-1}$ is a member of $SIZE_n(s)$. 
+By our choice of $i$, $f_{i-1}$ is a member of $SIZE_n(s)$.
 To complete the proof, we need to show that $f_i \in SIZE_n(s + 10n)$.
 Let $x^*$ be the string such that $lex(x^*)=i$ $b\in \{0,1\}$ be the value $f^*(x^*)$.
 Then we can define $f_i$ also as follows
@@ -223,12 +223,12 @@ f_i(x) = \begin{cases} b & x=x^* \\ f_i(x) & x \neq x^*
 $$
 or in other words
 $$
-f_i(x) = f_{i-1}(x) \wedge EQUAL(x^*,x) \; \vee \;  b \wedge \neg EQUAL(x^*,x) 
+f_i(x) = f_{i-1}(x) \wedge EQUAL(x^*,x) \; \vee \;  b \wedge \neg EQUAL(x^*,x)
 $$
 where $EQUAL:\{0,1\}^{2n} \rightarrow \{0,1\}$ is the function that maps $x,x' \in \{0,1\}^n$ to $1$ if they are equal and to $0$ otherwise.
 Since (by our choice of $i$), $f_{i-1}$ can be computed using at most $s$ gates and (as can be easily verified) that $EQUAL \in SIZE_n(9n)$,
 we can compute $f_i$ using at most $s + 9n +O(1) \leq s +10n$ gates which is what we wanted to prove.
-::: 
+:::
 
 
 
@@ -385,7 +385,7 @@ Specifically, since $EVAL_{s,n,m}$ is a finite function [bounded-univ](){.ref} i
 [bounded-univ](){.ref} establishes the existence of a NAND-CIRC program for computing $EVAL_{s,n,m}$, but it provides no explicit bound on the size of this program.
 [NAND-univ-thm](){.ref}, which we used to prove [bounded-univ](){.ref},   guarantees the existence of a NAND-CIRC program whose size can be as large as  _exponential_ in the length of its input.
 This would mean that even for moderately small values of $s,n,m$ (for example $n=100,s=300,m=1$), computing $EVAL_{s,n,m}$ might require a NAND program with more lines than there are atoms in the observable universe!
-Fortunately, we can do much better than that. 
+Fortunately, we can do much better than that.
 In fact, for every $s,n,m$ there exists a NAND-CIRC program for computing $EVAL_{s,n,m}$ with size that is  _polynomial_ in its input length.
 This is shown in the following theorem.
 
@@ -533,9 +533,9 @@ Please make sure that you understand why `GET` and $LOOKUP_\ell$ are the same fu
 We saw that we can compute $LOOKUP_\ell$  in time $O(2^\ell) =  O(s)$ for our choice of $\ell$.
 
 For every $\ell$, let $UPDATE_\ell:\{0,1\}^{2^\ell + \ell +1} \rightarrow \{0,1\}^{2^\ell}$ correspond to the  `UPDATE` function for arrays of length $2^\ell$.
-That is,  on input $V\in \{0,1\}^{2^\ell}$ , $i\in \{0,1\}^\ell$, $b\in \{0,1\}$, $UPDATE_\ell(V,b,i)$ is equal to $V' \in \{0,1\}^{2^\ell}$ such that 
+That is,  on input $V\in \{0,1\}^{2^\ell}$ , $i\in \{0,1\}^\ell$, $b\in \{0,1\}$, $UPDATE_\ell(V,b,i)$ is equal to $V' \in \{0,1\}^{2^\ell}$ such that
 $$
-V'_j = \begin{cases} V_j & j \neq i \\ b & j = 1 \end{cases} 
+V'_j = \begin{cases} V_j & j \neq i \\ b & j = 1 \end{cases}
 $$
 where we identify the string $i \in \{0,1\}^\ell$ with a number in  $\{0,\ldots, 2^{\ell}-1 \}$ using the binary representation.
 We can compute $UPDATE_\ell$ using an $O(2^\ell \ell)=(s \log s)$ line NAND-CIRC program as as follows:
@@ -560,7 +560,7 @@ def UPDATE_ell(V,i,b):
 
 
 
-Since the loop over `j` in `UPDATE` is run $2^\ell$ times, and computing `EQUALS_j` takes $O(\ell)$ lines, the total number of lines to compute `UPDATE` is $O(2^\ell \cdot \ell) = O(s \log s)$. 
+Since the loop over `j` in `UPDATE` is run $2^\ell$ times, and computing `EQUALS_j` takes $O(\ell)$ lines, the total number of lines to compute `UPDATE` is $O(2^\ell \cdot \ell) = O(s \log s)$.
 Once we can compute `GET` and `UPDATE`, the rest of the implementation amounts to "book keeping" that needs to be done carefully, but is not too insightful, and hence we omit the full details.
 Since we run `GET` and `UPDATE`  $s$ times, the total number of lines for computing $EVAL_{s,n,m}$ is $O(s^2) + O(s^2 \log s) = O(s^2 \log s)$.
 This completes (up to the omitted details) the proof of [eff-bounded-univ](){.ref}.

--- a/lec_06_loops.md
+++ b/lec_06_loops.md
@@ -168,7 +168,7 @@ We describe the operation of our Turing Machine $M$ in words:
 
 * Once $M$ found such a symbol $b \in \{0,1\}$, $M$ deletes $b$ from the tape by writing the $\times$ symbol, it enters either the `RIGHT_0` or `RIGHT_1` mode according to the value of $b$ and starts moving rightwards until it hits the first $\varnothing$ or $\times$ symbol.
 
-* Once we found this symbol we
+* Once we found this symbol we go
  into the state `LOOK_FOR_0` or `LOOK_FOR_1` depending on whether we were in the state `RIGHT_0` or `RIGHT_1` and make one left move.
 
 * In the state `LOOK_FOR_`$b$, we check whether the value on the tape is $b$. If it is, then we delete it by changing its value to $\times$, and move to the state `RETURN`. Otherwise, we change to the `OUTPUT_0` state.

--- a/lec_06_loops.md
+++ b/lec_06_loops.md
@@ -166,9 +166,9 @@ We describe the operation of our Turing Machine $M$ in words:
 
 * $M$ starts in state `START` and will go right, looking for the first symbol that is $0$ or $1$. If we find $\varnothing$ before we hit such a symbol then we will move to the `OUTPUT_1` state that we describe below.
 
-* Once $M$ found such a symbol $b \in \{0,1\}$, $M$ deletes $b$ from the tape by writing the $\times$ symbol, it enters either the `RIGHT_0` or `RIGHT_1` mode according to the value of $b$ and starts moving rightwards until it hits the first $\varnothing$ or $\times$ symbol.
+* Once $M$ finds such a symbol $b \in \{0,1\}$, $M$ deletes $b$ from the tape by writing the $\times$ symbol, it enters either the `RIGHT_0` or `RIGHT_1` mode according to the value of $b$ and starts moving rightwards until it hits the first $\varnothing$ or $\times$ symbol.
 
-* Once we found this symbol we go
+* Once we find this symbol we go
  into the state `LOOK_FOR_0` or `LOOK_FOR_1` depending on whether we were in the state `RIGHT_0` or `RIGHT_1` and make one left move.
 
 * In the state `LOOK_FOR_`$b$, we check whether the value on the tape is $b$. If it is, then we delete it by changing its value to $\times$, and move to the state `RETURN`. Otherwise, we change to the `OUTPUT_0` state.

--- a/lec_06_loops.md
+++ b/lec_06_loops.md
@@ -133,7 +133,7 @@ Specifically, a computation of a Turing Machine $M$ with $k$ states and alphabet
 
 Let $PAL$ (for _palindromes_) be the function that on input $x\in \{0,1\}^*$, outputs $1$ if and only if $x$ is an (even length) _palindrome_, in the sense that $x = w_0 \cdots w_{n-1}w_{n-1}w_{n-2}\cdots w_0$ for some $n\in \N$ and $w\in \{0,1\}^n$.
 
-We now show a Turing Machine $M$ that computes $PAL$. To specify $M$ we need to specify __(i)__ $M$'s tape alphabet $\Sigma$ which should contain at least the symboles $0$,$1$, $\triangleright$ and $\varnothing$, and __(ii)__ $M$'s _transition function_ which determines what action $M$ takes when it reads a given symbol while it is in a particular state.
+We now show a Turing Machine $M$ that computes $PAL$. To specify $M$ we need to specify __(i)__ $M$'s tape alphabet $\Sigma$ which should contain at least the symbols $0$,$1$, $\triangleright$ and $\varnothing$, and __(ii)__ $M$'s _transition function_ which determines what action $M$ takes when it reads a given symbol while it is in a particular state.
 
 In our case, $M$ will use the alphabet $\{ 0,1,\triangleright, \varnothing, \times \}$ and will have $k=14$ states. Though the states are simply numbers between $0$ and $k-1$, for convenience we will give them the following labels:
 
@@ -322,9 +322,9 @@ For example, consider the Turing Machine $M$ of [turingmachinepalindrome](){.ref
 We can also describe this machine as a _program_ using the Python-like pseudocode of the form below
 
 ```python
-# Gets an array Tape initialized to 
+# Gets an array Tape initialized to
 # [">", x_0 , x_1 , .... , x_(n-1), "∅", "∅", ...]
-# At the end of the execution, Tape[1] is equal to 1 
+# At the end of the execution, Tape[1] is equal to 1
 # if x is a palindrome and is equal to 0 otherwise
 def PAL(Tape):
     head = 0
@@ -349,7 +349,7 @@ The _state_ is a _local register_ that can hold one of a fixed number of values 
 More generally we can think of every Turing Machine $M$ as equivalent to a program similar to the following:
 
 ```python
-# Gets an array Tape initialized to 
+# Gets an array Tape initialized to
 # [">", x_0 , x_1 , .... , x_(n-1), "∅", "∅", ...]
 def M(Tape):
     state = 0
@@ -415,7 +415,7 @@ Concretely, the NAND-TM programming language adds the following features on top 
   - If $a=b=0$ then `MODANDJUMP(`$a,b$`)` halts execution of the program.
 
 
-* The`MODANDJUMP` instruction always appears in the last line of a NAND-TM program and nowhere else. 
+* The`MODANDJUMP` instruction always appears in the last line of a NAND-TM program and nowhere else.
 
 
 __Default values.__ We need one more convention to handle "default values".
@@ -650,18 +650,18 @@ But we can go beyond this and achieve for example:
 
 * Inner loops such as the `while` and `for` operations commong to many programming language.s
 
-* Multiple index variables (e.g., not just `i` but we can add `j`, `k`, etc.). 
+* Multiple index variables (e.g., not just `i` but we can add `j`, `k`, etc.).
 
 * Arrays with more than one dimension  (e.g., `Foo[i][j]`, `Bar[i][j][k]` etc.)
 
 In all of these cases (and many others) we can implement the new feature as mere "syntactic sugar" on top of standard NAND-TM, which means that the set of functions computable by NAND-TM with this feature is the same as the set of functions computable by standard NAND-TM.
 Similarly, we can show that the set of functions computable by Turing Machines that have more than one tape, or tapes of more dimensions than one, is the same as the set of functions computable by standard Turing machines.
 
-### "GOTO" and inner loops 
+### "GOTO" and inner loops
 
 We can implement more advanced _looping constructs_ than the simple `MODANDJUMP`.
 For example, we can implement `GOTO`.
-A `GOTO` statement corresponds to jumping to a certain line in the execution. 
+A `GOTO` statement corresponds to jumping to a certain line in the execution.
 For example, if we have code of the form
 
 ```python
@@ -675,7 +675,7 @@ then the program will only do `foo` and `blah` as when it reaches the line `GOTO
 We can achieve the effect of `GOTO` in NAND-TM using conditionals.
 In the code below, we assume that we have a variable `pc` that can take strings of some constant length.
 This can be encoded using a finite  number of Boolean variables `pc_0`, `pc_1`, $\ldots$, `pc_`$k-1$, and so when we write below
-`pc = "label"` what we mean is something like `pc_0 = 0`,`pc_1 = 1`, $\ldots$ (where the bits $0,1,\ldots$ correspond to the encoding of the finite string `"label"` as a string of length $k$). 
+`pc = "label"` what we mean is something like `pc_0 = 0`,`pc_1 = 1`, $\ldots$ (where the bits $0,1,\ldots$ correspond to the encoding of the finite string `"label"` as a string of length $k$).
 We also assume that we have access to conditional (i.e., `if` statements), which we can emulate using syntactic sugar in the same way as we did in NAND-CIRC.
 
 To emulate a GOTO statement, we will first modify a program P of the form
@@ -714,14 +714,14 @@ while foo:
 do bar
 ```
 
-with 
+with
 
 ```python
-"loop": 
+"loop":
     if NOT(foo): GOTO("next")
     do blah
     GOTO("loop")
-"next": 
+"next":
     do bar
 ```
 
@@ -909,7 +909,7 @@ Augusta Ada Byron, countess of Lovelace (1815-1852) lived a short but turbulent 
 (see [@stein1987ada] for a biography).
 Ada took an immense interest in Babbage's _analytical engine_, which we mentioned in [compchap](){.ref}.
 In 1842-3, she translated from Italian a paper of Menabrea on the engine,  adding copious notes (longer than the paper itself).
-The quote in the chapter's beginning is taken from Nota A in this text. 
+The quote in the chapter's beginning is taken from Nota A in this text.
 Lovelace's notes contain several examples of _programs_ for the analytical engine, and because of this she has been called  "the world's first computer programmer" though it is not clear whether they were written by Lovelace or Babbage himself [@holt2001ada].
 Regardless, Ada was clearly one of very few people (perhaps the only one outside of Babbage himself) to fully appreciate how significant and revolutionary the idea of mechanizing computation truly is.
 
@@ -947,5 +947,3 @@ We will not use this terminology in this book.
 One of the first programming-language formulations of Turing machines was given by Wang [@Wang1957]. Our formulation of NAND-TM is aimed at making the connection with circuits more direct, with the eventual goal of using it for the Cook-Levin Theorem, as well as results such as $\mathbf{P} \subseteq \mathbf{P_{/poly}}$ and  $\mathbf{BPP} \subseteq \mathbf{P_{/poly}}$.
 The website [esolangs.org](https://esolangs.org) features a large variety of esoteric Turing-complete programming languages.
 One of the most famous of them is [Brainf*ck](https://esolangs.org/wiki/Brainfuck).
-
-


### PR DESCRIPTION
Before creating this PR, I made sure to sync my fork since it had fallen a few commits behind. There was a merge conflict in the lecture 3 file, and I think I kept the correct versions, though a second pair of eyes to confirm would be good.

In short, the whole point of the PR was to fix the typo "gives somewhat worse quantitative bound" to "gives a somewhat worse quantitative bound" (the "a" had been omitted).

Also, still not sure why GitHub thinks I'm changing some lines when I'm not (it seems to think I'm deleting a space at the end of them, or something?)