### PR TITLE
Fix two typos and repair NtS program

### DIFF
--- a/acknowledgements.md
+++ b/acknowledgements.md
@@ -5,6 +5,7 @@ If you make a pull request, please also add your name here in the alphabetical o
 * Scott Aaronson
 * Michele Amoretti
 * Marguerite Basta
+* Anindya Basu
 * Sam Benkelman
 * Jarosław Błasiok
 * Emily Chan
@@ -14,17 +15,21 @@ If you make a pull request, please also add your name here in the alphabetical o
 * Chi-Ning Chou
 * Michael Colavita
 * Robert Darley Waddilove
+* Anlan Du
 * Juan Esteller
 * David Evans
 * Michael Fine
+* Simon Fischer
 * Leor Fishman
 * Zaymon Foulds-Cook
 * William Fu
 * Kent Furuie
 * Piotr Galuszka
+* Carolyn Ge
 * Mark Goldstein
 * Alexander Golovnev
 * Michael Haak
+* Joosep Hook
 * Thomas HUET
 * Emily Jia
 * Chan Kang
@@ -74,14 +79,10 @@ If you make a pull request, please also add your name here in the alphabetical o
 * Jonah Weissman
 * Ryan Williams
 * Licheng Xu
+* Richard Xu
 * Wanqian Yang
 * Elizabeth Yeoh-Wang
 * Josh Zelinsky
 * Fred Zhang
 * Grace Zhang
 * Jessica Zhu
-* Anindya Basu
-* Joosep Hook
-* Richard Xu
-* Carolyn Ge
-* Anlan Du

--- a/lec_00_1_math_background.md
+++ b/lec_00_1_math_background.md
@@ -624,7 +624,7 @@ There are some simple heuristics that can help when trying to compare two functi
 ::: {.remark title="Big $O$ for other applications (optional)" #bigonotime}
 While Big-$O$ notation is often used to analyze running time of algorithms, this is by no means the only application.
 We can use $O$ notation to bound asymptotic relations between any functions mapping integers to positive numbers. It can be used regardless of whether these functions are a measure of running time, memory usage, or any other quantity that may have nothing to do with computation.
-Here is one example which is unrelated to this book (and hence one that you can feel free to skip): one way to state the [Riemann Hypothesis](https://en.wikipedia.org/wiki/Riemann_hypothesis) (one of the most famous open questions in mathematics) is that it corresponds to the conjecture that the number of primers between $0$ and $n$ is equal to $\int_2^n \tfrac{1}{\ln x} dx$ up to an additive error of magnitude at most $O(\sqrt{n}\log n)$.
+Here is one example which is unrelated to this book (and hence one that you can feel free to skip): one way to state the [Riemann Hypothesis](https://en.wikipedia.org/wiki/Riemann_hypothesis) (one of the most famous open questions in mathematics) is that it corresponds to the conjecture that the number of primes between $0$ and $n$ is equal to $\int_2^n \tfrac{1}{\ln x} dx$ up to an additive error of magnitude at most $O(\sqrt{n}\log n)$.
 :::
 
 

--- a/lec_01_introduction.md
+++ b/lec_01_introduction.md
@@ -121,7 +121,7 @@ A full description of an algorithm has three components:
 
 * __Analysis:__ __Why__ does this sequence of instructions achieve the desired task. A full description of [naivemultalg](){.ref} and [gradeschoolalg](){.ref} will include a _proof_ for each one of these algorithms that on input $x,y$, the algorithm does indeed output $x\cdot y$.
 
-Often as part of the analysis we show that the algorithm is not only __correct__ but also __efficient__. That is, we want to show that not only will the algorithm compute the desired task, but will do so in prescribed number of operations. For example [gradeschoolalg](){.ref} computes the multiplication function on inputs of $n$ digits using $O(n^2)$ operations, while [karatsubaalg](){.ref} (described below) computes the same function using $O(n^{1.6})$ operations. (We define the $O$ notations used here in [secbigohnotation]{.ref}.)
+Often as part of the analysis we show that the algorithm is not only __correct__ but also __efficient__. That is, we want to show that not only will the algorithm compute the desired task, but will do so in prescribed number of operations. For example [gradeschoolalg](){.ref} computes the multiplication function on inputs of $n$ digits using $O(n^2)$ operations, while [karatsubaalg](){.ref} (described below) computes the same function using $O(n^{1.6})$ operations. (We define the $O$ notations used here in [secbigohnotation](){.ref}.)
 :::
 
 

--- a/lec_02_representation.md
+++ b/lec_02_representation.md
@@ -130,7 +130,7 @@ We can implement the binary representation in _Python_ as follows:
 
 ```python
 def NtS(n):# natural numbers to strings
-    if n // 2 > 0:
+    if n > 1:
         return NtS(n // 2) + str(n % 2)
     else:
         return str(n % 2)

--- a/lec_02_representation.md
+++ b/lec_02_representation.md
@@ -129,10 +129,11 @@ In fact, for most  purposes, we can even use the simpler representation of mappi
 We can implement the binary representation in _Python_ as follows:
 
 ```python
-from math import floor, log
-def NtS(n): # natural numbers to strings
-    if n<1: return ""
-    return NtS(floor(n/2))+str(n % 2)
+def NtS(n):# natural numbers to strings
+    if n // 2 > 0:
+        return NtS(n // 2) + str(n % 2)
+    else:
+        return str(n % 2)
 
 print(NtS(236))
 # 11101100


### PR DESCRIPTION
I fixed a typo (primers -> primes) and a broken reference to secbigohnotation, hopefully. Additionally, the NtS program given in remark 2.1 didn't work correctly for the case n = 0.