### PR TITLE
Add License terms to CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,8 @@ You can either do this by posting on the [issues](https://github.com/boazbk/tcs/
 
 In an issue, please also write your full name so I can acknowledge you properly. If you do a pull request, please also edit the file `acknowledgements.md` to add your name.
 
-These notes are provided under Creative Commons Attribution-NonCommercial-NoDerivatives 4.0 International License.
+These notes are provided under Creative Commons Attribution-NonCommercial-NoDerivatives 4.0 International License. To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-nd/4.0/ or send a letter to Creative Commons, PO Box 1866, Mountain View, CA 94042, USA.
+
 It will remain freely and publicly available, but I may also create a printed book version of these notes in the future.
 By making any contribution to this work, you are assigning me the rights to use your contribution in the online or any other version of this work.
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Introduction to Theoretical Computer Science
 
 This is the git repository for a book in preparation for an introductory undergraduate course on computer science.
-The book is posted (in both html and pdf formats)  on the web page [http://introtcs.org](http://introtcs.org)
+The book is posted (in both html and pdf formats)  on the web page https://introtcs.org
 
 Please use the [issues](https://github.com/boazbk/tcs/issues) and [pull requests](https://github.com/boazbk/tcs/pulls) to post any suggestions, comments, typo fixes, etc.
 
@@ -23,12 +23,12 @@ My priorities are:
 
 
 I am producing the book from the markdown source using 
-[Pandoc](http://pandoc.org/). 
+[Pandoc](https://pandoc.org/). 
 The templates for the LaTeX and HTML versions are derived from   [Tufte LaTeX](https://tufte-latex.github.io/tufte-latex/), [Gitbook](https://www.gitbook.com/) and [Bookdown](https://bookdown.org/). You can see the [scripts](https://github.com/boazbk/tcs/tree/master/scripts) directory for some of the templates, scripts and  [panflute](http://scorreia.com/software/panflute/) filter I am using.
 
 
 
-This work is licensed under the Creative Commons Attribution-NonCommercial-NoDerivatives 4.0 International License. To view a copy of this license, visit http://creativecommons.org/licenses/by-nc-nd/4.0/ or send a letter to Creative Commons, PO Box 1866, Mountain View, CA 94042, USA.
+This work is licensed under the Creative Commons Attribution-NonCommercial-NoDerivatives 4.0 International License. To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-nd/4.0/ or send a letter to Creative Commons, PO Box 1866, Mountain View, CA 94042, USA.
 
 While this text will remain freely and publicly available, I may also create a printed book version in the future.
 By making any contribution to this work, such as a typo fix or any other suggestion or edit, you are assigning me the rights to use your contribution in both the online or any other version of this work.


### PR DESCRIPTION
While a contributor opening a PR or issue from the book website may not read the readme, they will be prompted to read the contributor guidelines by GitHub itself.

Hence, it makes sense to have the contributing guide as complete as possible so there is no confusion in understanding the terms (for example they can't say they read the license name but didn't know what the terms implied). 

Also, changed the http link to https :)