### PR TITLE
fixed typo --> RAM machines

### DIFF
--- a/lec_07_other_models.md
+++ b/lec_07_other_models.md
@@ -49,7 +49,7 @@ The memory of a RAM machine is an array of unbounded size where each cell can st
 For example, many modern computing architectures use  $64$ bit words, in which every memory location holds a string in $\{0,1\}^{64}$ which can also be thought of as a number between $0$ and $2^{64}-1= 9,223,372,036,854,775,807$.
 The parameter $w$ is known as the _word size_.
 In practice often $w$ is a fixed number such as $64$, but when doing theory we model $w$ as a  parameter that can depend on the input length or number of steps.
-(You can think of $2^w$ as roughly corresponding to the largest memory address that we use in the computation.) 
+(You can think of $2^w$ as roughly corresponding to the largest memory address that we use in the computation.)
 In addition to the memory array, a RAM machine also contains a constant number of _registers_ $r_0,\ldots,r_{k-1}$, each of which can also contain a single word.
 
 
@@ -58,7 +58,7 @@ In addition to the memory array, a RAM machine also contains a constant number o
 
 The operations a RAM machine can carry out include:
 
-* __Data movement:__ Load data from a certain cell in memory into a register or store the contents of a register into a certain cell of memory. RAM machine can directly access any cell of memory without having to move the "head" (as Turing machines do) to that location. That is, in one step a RAM machine can load into register $r_i$ the contents of the memory cell indexed by register $r_j$, or store into the memory cell indexed by register $r_j$ the contents of register $r_i$. 
+* __Data movement:__ Load data from a certain cell in memory into a register or store the contents of a register into a certain cell of memory. RAM machine can directly access any cell of memory without having to move the "head" (as Turing machines do) to that location. That is, in one step a RAM machine can load into register $r_i$ the contents of the memory cell indexed by register $r_j$, or store into the memory cell indexed by register $r_j$ the contents of register $r_i$.
 
 * __Computation:__ RAM machines can carry out computation on registers such as arithmetic operations, logical operations, and comparisons.
 
@@ -66,17 +66,17 @@ The operations a RAM machine can carry out include:
 
 
 We will not give a formal definition of RAM Machines, though the bibliographical notes section ([othermodelsbibnotes](){.ref}) contains sources for such definitions.
-Just as the NAND-TM programming language models Turing machines, we can also define a  _NAND-RAM programming language_ that models Turing machines.
+Just as the NAND-TM programming language models Turing machines, we can also define a  _NAND-RAM programming language_ that models RAM machines.
 The NAND-RAM programming language extends NAND-TM by adding the following features:
 
 
-* The variables of NAND-RAM are allowed to be (non negative) _integer valued_ rather than only Boolean as is the case in NAND-TM. That is, a scalar variable `foo` holds an non negative integer in $\N$ (rather than only a bit in $\{0,1\}$), and an array variable `Bar` holds an array of integers. As in the case of RAM machines, we will not allow integers of unbounded size. Concretely, each variable holds a number between $0$ and $T-1$, where $T$ is the number of steps that have been executed by the program so far. (You can ignore this restriction for now:  if we want to hold larger numbers, we can simply execute dummy instructions; it will be useful in later chapters.) 
+* The variables of NAND-RAM are allowed to be (non negative) _integer valued_ rather than only Boolean as is the case in NAND-TM. That is, a scalar variable `foo` holds an non negative integer in $\N$ (rather than only a bit in $\{0,1\}$), and an array variable `Bar` holds an array of integers. As in the case of RAM machines, we will not allow integers of unbounded size. Concretely, each variable holds a number between $0$ and $T-1$, where $T$ is the number of steps that have been executed by the program so far. (You can ignore this restriction for now:  if we want to hold larger numbers, we can simply execute dummy instructions; it will be useful in later chapters.)
 
 * We allow _indexed access_ to arrays. If `foo` is a scalar and `Bar` is an array, then `Bar[foo]` refers to the location of `Bar` indexed by the value of `foo`. (Note that this means we don't need to have a special index variable `i` any more.)
 
 * As is often the case in programming languages, we will assume that for Boolean operations such as `NAND`, a zero valued integer is considered as _false_, and a nonzero valued integer is considered as _true_.
 
-* In addition to `NAND`, NAND-RAM also includes all the basic arithmetic operations of addition, subtraction, multiplication, (integer) division, as well as comparisons (equal, greater than, less than, etc..). 
+* In addition to `NAND`, NAND-RAM also includes all the basic arithmetic operations of addition, subtraction, multiplication, (integer) division, as well as comparisons (equal, greater than, less than, etc..).
 
 * NAND-RAM includes conditional statements `if`/`then` as part of the language.
 
@@ -87,7 +87,7 @@ As usual, we can implement other looping constructs such as `goto` and `while` o
 
 
 A full description of the NAND-RAM programming language is in the appendix.
-However, the most important fact you need to know about NAND-RAM is that you actually don't need to know much about NAND-RAM at all, since it is equivalent in power to Turing machines: 
+However, the most important fact you need to know about NAND-RAM is that you actually don't need to know much about NAND-RAM at all, since it is equivalent in power to Turing machines:
 
 > ### {.theorem title="Turing Machines (aka NAND-TM programs) and RAM machines (aka NAND-RAM programs) are equivalent" #RAMTMequivalencethm}
 For every function $F:\{0,1\}^* \rightarrow \{0,1\}^*$, $F$ is computable by a NAND-TM program if and only if $F$ is computable by a NAND-RAM program.
@@ -105,7 +105,7 @@ The transformation has two steps:
 
 1. _Indexed access of bit arrays:_  We start by showing how to handle __(a)__. Namely, we show how we can implement in NAND-TM the operation `Setindex(Bar)` such that if `Bar` is an array that encodes some integer $j$, then after executing `Setindex(Bar)` the value of `i` will equal to $j$. This will allow us to simulate syntax of the form `Foo[Bar]` by `Setindex(Bar)` followed by `Foo[i]`.
 
-2. _Two dimensional bit arrays:_ We then show how we can use "syntactic sugar" to augment NAND-TM with _two dimensional arrays_. That is, have _two indices_ `i` and `j` and _two dimensional arrays_, such that we can use the syntax `Foo[i][j]` to access the (`i`,`j`)-th location of `Foo`. 
+2. _Two dimensional bit arrays:_ We then show how we can use "syntactic sugar" to augment NAND-TM with _two dimensional arrays_. That is, have _two indices_ `i` and `j` and _two dimensional arrays_, such that we can use the syntax `Foo[i][j]` to access the (`i`,`j`)-th location of `Foo`.
 
 3. _Arrays of integers:_ Finally we will encode a one dimensional array `Arr` of _integers_ by a two dimensional `Arrbin` of _bits_. The idea is simple: if $a_{i,0},\ldots,a_{i,\ell}$ is a binary  (prefix-free) representation of `Arr[`$i$`]`, then `Arrbin[`$i$`][`$j$`]` will be equal to $a_{i,j}$.
 
@@ -204,7 +204,7 @@ $$embed(x,y) = \tfrac{1}{2}(x+y)(x+y+1)+x\;\;.$$
 
 ![Illustration of the map $embed(x,y) = \tfrac{1}{2}(x+y)(x+y+1)+x$ for $x,y \in [10]$, one can see that for every distinct pairs $(x,y)$ and $(x',y')$, $embed(x,y) \neq embed(x',y')$. ](../figure/pairing_function.png){#pairingfuncfig .margin  }
 
-[pair-ex](){.ref} asks you to prove that $embed$ is indeed one to one, as well as computable by a NAND-TM program. (The latter can be done by simply following the grade-school algorithms for multiplication, addition, and division.) 
+[pair-ex](){.ref} asks you to prove that $embed$ is indeed one to one, as well as computable by a NAND-TM program. (The latter can be done by simply following the grade-school algorithms for multiplication, addition, and division.)
 This means that we can replace code of the form `Two[Foo][Bar] = something` (i.e., access the two dimensional array `Two` at the integers encoded by the one dimensional arrays `Foo` and `Bar`) by code of the form:
 
 ```python
@@ -317,7 +317,7 @@ Initialize empty queue $Q$.
 Put $u$ in $Q$
 While{$Q$ is not empty}
    Remove top vertex $w$ from $Q$
-   If{$w=v$} return "connected" endif 
+   If{$w=v$} return "connected" endif
    Mark $w$
    Add all unmarked neighbors of $w$ to $Q$.
 Endwhile
@@ -351,7 +351,7 @@ Hence, in cases where the precise representation doesn't make a difference, we w
 
 
 
-__Defining "Algorithms".__ 
+__Defining "Algorithms".__
 Up until now we have use the term "algorithm" informally.
 However, Turing Machines and the range of equivalent models yield a way to precisely and formally define algorithms.
 Hence whenever we refer to an _algorithm_ in this book, we will mean that it is an instance of one of the Turing equivalent models, such as Turing machines, NAND-TM, RAM machines, etc.
@@ -363,7 +363,7 @@ Because of the equivalence of all these models, in many contexts, it will not ma
 A _computational model_ is some way to define what it means for a _program_ (which is represented by a string) to compute a (partial) _function_.
 A _computational model_ $\mathcal{M}$ is _Turing complete_, if we can map every Turing machine (or equivalently NAND-TM program) $N$ into a program $P$ for $\mathcal{M}$ that computes the same function as $Q$.
 It is _Turing equivalent_ if the other direction holds as well (i.e., we can map every program in $\mathcal{M}$ to a Turing machine that computes the same function).
-We can define this notion formally as follows. 
+We can define this notion formally as follows.
 (This formal definition is not crucial for the remainder of this book so feel  to skip it as long as you understand the general concept of Turing equivalence; This notion is sometimes referred to in the literature as [Gödel numbering](https://goo.gl/rzuNPu) or [admissable numbering](https://goo.gl/xXJoUG).)
 
 ::: {.definition title="Turing completeness and equivalence (optional)" #turingcompletedef}
@@ -450,7 +450,7 @@ For example, as simple as its rules seem, we can simulate a Turing machine using
 
 
 
-In fact, even [one dimensional cellular automata](https://en.wikipedia.org/wiki/Rule_110) can be Turing complete: 
+In fact, even [one dimensional cellular automata](https://en.wikipedia.org/wiki/Rule_110) can be Turing complete:
 
 ::: {.theorem title="One dimensional automata are Turing complete" #onedimcathm}
 For every Turing machine  $M$,  there is a one dimension cellular automaton that can simulate $M$ on every input $x$.
@@ -521,7 +521,7 @@ Completing the full proof is not hard, but doing it is a great way to ensure tha
 __Completing the proof of  [onedimcathm](){.ref}.__ We can now restate [onedimcathm](){.ref} more formally, and complete its proof:
 
 ::: {.theorem title="One dimensional automata are Turing complete (formal statement)" #onedimcathmformal}
-For every Turing Machine $M$, there is a one-dimensional cellular automaton $r$ over the alphabet $\overline{\Sigma}^*$  such that 
+For every Turing Machine $M$, there is a one-dimensional cellular automaton $r$ over the alphabet $\overline{\Sigma}^*$  such that
 $$E \left( NEXT_M(\alpha) \right)  = NEXT_r \left( E(\alpha) \right)$$
 for every configuration $\alpha \in \overline{\Sigma^*}$ of $M$, where we denote by $E(\alpha)$ the natural extension of $\alpha$ to a configuration of $r$ obtained by defining $E(\alpha)_i = \alpha_i$ for every $i\in\{0,1, \ldots, |\alpha|-1 \}$ and $E(\alpha)_j = \varnothing$ for every $j$ such that $j<0$ or $j\geq |\alpha|$.
 :::
@@ -578,7 +578,7 @@ $$
 $$
 
 and so $(\lambda x.x\times x)(7)=49$.
-That is, you can think of $\lambda x.  exp(x)$, where $exp$ is some expression as a way of specifying the anonymous function $x \mapsto exp(x)$. 
+That is, you can think of $\lambda x.  exp(x)$, where $exp$ is some expression as a way of specifying the anonymous function $x \mapsto exp(x)$.
 Anonymous functions, using either   $\lambda x.f(x)$, $x \mapsto f(x)$ or other closely related notation, appear in many programming languages.
 For example, in _Python_ we can define the squaring function using `lambda x: x*x` while in _JavaScript_ we can use `x => x*x` or `(x) => x*x`. In _Scheme_ we would define it as `(lambda (x) (* x x))`.
 Clearly, the name of the argument to a function doesn't matter, and so $\lambda y.y\times y$ is the same as $\lambda x.x \times x$, as both correspond to the squaring function.
@@ -665,7 +665,7 @@ By our rules of associativity, this is the same as $(f a b)$ which we'll sometim
 ### Formal description of the λ calculus.
 
 We now provide a formal description of the λ calculus.
-We start with  "basic expressions" that contain a single variable such as $x$ or $y$ and build more complex expressions of the form $(e \; e')$ and $\lambda x.e$ where $e,e'$ are expressions and $x$ is a variable idenifier. 
+We start with  "basic expressions" that contain a single variable such as $x$ or $y$ and build more complex expressions of the form $(e \; e')$ and $\lambda x.e$ where $e,e'$ are expressions and $x$ is a variable idenifier.
 Formally λ expressions are defined as follows:
 
 
@@ -673,9 +673,9 @@ Formally λ expressions are defined as follows:
 ::: {.definition title="λ expression." #lambdaexpdef}
 A _λ expression_ is either a single variable identifier or an expression $e$ of the one of the following forms:
 
-* __Application:__ $e = (e' \; e'')$, where $e'$ and $e''$ are λ expressions. 
+* __Application:__ $e = (e' \; e'')$, where $e'$ and $e''$ are λ expressions.
 
-* __Abstraction:__ If $e = \lambda x.(e')$ where $e'$ is a λ expression. 
+* __Abstraction:__ If $e = \lambda x.(e')$ where $e'$ is a λ expression.
 :::
 
 [lambdaexpdef](){.ref} is a _recursive definition_ since we defined the concept of λ expressions in terms of itself.
@@ -698,7 +698,7 @@ Another rule that we can use is that the parameter does not matter and hence for
 Together these rules define the notion of _equivalence_ of λ expressions:
 
 ::: {.definition title="Equivalence of λ expressions" #lambdaequivalence}
-Two λ expressions are _equivalent_ if they can be made into the same expression by repeated applications of the following rules: 
+Two λ expressions are _equivalent_ if they can be made into the same expression by repeated applications of the following rules:
 
 1. __Evaluation (aka $\beta$ reduction):__ The expression $(\lambda x.exp) exp'$ is equivalent to $exp[x \rightarrow exp']$.
 
@@ -729,11 +729,11 @@ Formally, the evaluation of a λ expression using "call by name" is captured by 
 ::: {.definition title="Simplification of λ expressions" #simplifylambdadef }
 Let $e$ be a λ expression. The _simplification_ of $e$ is the result of the following recursive process:
 
-1. If  $e$ is a single variable $x$ then the simplification of $e$ is $e$. 
+1. If  $e$ is a single variable $x$ then the simplification of $e$ is $e$.
 
-2. If $e$ has the form  $e= \lambda x.e'$ then the simplification of $e$ is $\lambda x.f'$ where $f'$ is the simplification of $f'$. 
+2. If $e$ has the form  $e= \lambda x.e'$ then the simplification of $e$ is $\lambda x.f'$ where $f'$ is the simplification of $f'$.
 
-3. _(Evaluation / $\beta$ reduction.)_  If $e$ has the form  $e=(\lambda x.e' \; e'')$ then the simplification of $e$ is the simplification of $e'[x \rightarrow e'']$, which denotes replacing all copies of $x$ in $e'$ bound  to the $\lambda$ operator with $e''$ 
+3. _(Evaluation / $\beta$ reduction.)_  If $e$ has the form  $e=(\lambda x.e' \; e'')$ then the simplification of $e$ is the simplification of $e'[x \rightarrow e'']$, which denotes replacing all copies of $x$ in $e'$ bound  to the $\lambda$ operator with $e''$
 
 4. _(Renaming / $\alpha$ conversion.)_ The _canonical simplification_ of $e$ is obtained by taking the simplification of $e$ and renaming the variables so that the first bound variable in the expression is $v_0$, the second one is $v_1$, and so on and so forth.
 
@@ -877,7 +877,7 @@ The result of simplifying a λ expression is an equivalent expression, and hence
 :::  {.definition title="Computing a function via λ calculus" #lambdacomputedef   }
 Let $F:\{0,1\}^* \rightarrow \{0,1\}^*$
 
-We say that _$exp$ computes $F$_ if for every $x\in \{0,1\}^*$, 
+We say that _$exp$ computes $F$_ if for every $x\in \{0,1\}^*$,
 
 $$exp \langle x_0,\ldots,x_{n-1},\bot \langle \cong \langle y_0,\ldots, y_{m-1}, \bot \rangle$$
 
@@ -916,7 +916,7 @@ By [NANDlambdaex](){.ref}, we can compute the $NAND$ function, and hence _every_
 Using this insight, we can compute $NEXT_M$ using the λ calculus as follows.
 Given a list $L$ encoding the configuration $\alpha_0\cdots \alpha_{m-1}$, we define the lists $L_{prev}$ and $L_{next}$ encoding the configuration $\alpha$ shifted by one step to the right and left respectively.
 The next configuration $\alpha'$ is defined as $\alpha'_i = r(L_{prev}[i],L[i],L_{next}[i])$ where we let $L'[i]$ denote the $i$-th element of $L'$.
-This can be computed by recursion (and hence using the enhanced λ calculus' $RECURSE$ operator) as follows: 
+This can be computed by recursion (and hence using the enhanced λ calculus' $RECURSE$ operator) as follows:
 
 ``` {.algorithm title="$NEXT_M$ using the λ calculus" #nextmlambdacalc}
 INPUT: List $L = \langle \alpha_0,\alpha_1,\ldots, \alpha_{m-1}, \bot \rangle$ encoding a configuration $\alpha$.
@@ -1083,7 +1083,7 @@ Let's test this out:
 myxor(myxor,[1,0,1])
 ```
 
-If you do this, you will get the following complaint from the interpreter: 
+If you do this, you will get the following complaint from the interpreter:
 
 `TypeError: myxor() missing 1 required positional argument`
 

--- a/lec_07_other_models.md
+++ b/lec_07_other_models.md
@@ -352,7 +352,7 @@ Hence, in cases where the precise representation doesn't make a difference, we w
 
 
 __Defining "Algorithms".__
-Up until now we have use the term "algorithm" informally.
+Up until now we have used the term "algorithm" informally.
 However, Turing Machines and the range of equivalent models yield a way to precisely and formally define algorithms.
 Hence whenever we refer to an _algorithm_ in this book, we will mean that it is an instance of one of the Turing equivalent models, such as Turing machines, NAND-TM, RAM machines, etc.
 Because of the equivalence of all these models, in many contexts, it will not matter which of these we use.

--- a/lec_07_other_models.md
+++ b/lec_07_other_models.md
@@ -460,7 +460,7 @@ To make the notion of "simulating a Turing machine"   more precise we will need 
 We will do so in [turingmachinesconfigsec](){.ref} below, but at a high level a _configuration_ of a Turing machine is a string that encodes its full state at  a given step in its computation.
 That is, the contents of all (non empty) cells of its tape, its current state, as well as the head position.
 
-The key idea in the proof of [onedimcathm](){.ref}, that at every point in the computation of a Turing machine $M$, the only cell in $M$'s tape that can change is the one where the head is located, and the value this cell changes to is a function of its current state and the finite state of $M$.
+The key idea in the proof of [onedimcathm](){.ref} is that at every point in the computation of a Turing machine $M$, the only cell in $M$'s tape that can change is the one where the head is located, and the value this cell changes to is a function of its current state and the finite state of $M$.
 This observation allows us to encode the configuration of a Turing machine $M$ as a finite configuration of a cellular automaton $r$, and ensure that a one-step evolution of this encoded configuration under the rules of $r$ corresponds to one step in the execution of the Turing machine $M$.
 
 
@@ -468,7 +468,7 @@ This observation allows us to encode the configuration of a Turing machine $M$ a
 ### Configurations of Turing machines and the next-step function  {#turingmachinesconfigsec }
 
 To turn the above ideas into a rigorous proof (and even statement!) of [onedimcathm](){.ref} we will need precisely define the notion of _configurations_ of Turing machines.
-This notion will be useful for us in later chapters we well.
+This notion will be useful for us in later chapters as well.
 
 
 ![A _configuration_ of a Turing machine $M$ with alphabet $\Sigma$ and state space $[k]$ encodes the state of $M$ at a particular step in its execution as a string $\alpha$ over the alphabet $\overline{\Sigma} = \Sigma \times (\{\cdot \} \times [k])$. The string is of length $t$ where $t$ is such that $M$'s tape contains $\varnothing$ in all positions $t$ and larger and $M$'s head is in a position smaller than $t$.


### PR DESCRIPTION
Textbook said NAND-RAM modeled Turing machines. Also, GitHub still thinks I'm removing whitespaces at the end of paragraphs for some reason. Maybe it's my text editor.