### PR TITLE
0.12^n -> 0.1 * 2^n in Size Hierarchy Theorem

### DIFF
--- a/lec_04_code_and_data.md
+++ b/lec_04_code_and_data.md
@@ -186,7 +186,7 @@ It turns out that we can use [counting-lb](){.ref} to show a more general result
 
 
 > ### {.theorem title="Size Hierarchy Theorem" #sizehiearchythm}
-For every sufficiently large $n$ and $10n < s < 0.1 2^n /n$,
+For every sufficiently large $n$ and $10n < s < 0.1 \cdot 2^n /n$,
 $$
 SIZE_n(s) \subsetneq SIZE_n(s+10n) \;.
 $$


### PR DESCRIPTION
Right now, the theorem reads `$10n < s < 0.1 2^n /n$`, which renders as 0.12^n and confused me. This PR puts in a cdot to clarify.