### PR TITLE
Updated proof of theorem 18.5

### DIFF
--- a/acknowledgements.md
+++ b/acknowledgements.md
@@ -91,3 +91,4 @@ If you make a pull request, please also add your name here in the alphabetical o
 * Fred Zhang
 * Grace Zhang
 * Jessica Zhu
+* Owen Niles

--- a/lec_16_randomized_alg.md
+++ b/lec_16_randomized_alg.md
@@ -274,8 +274,9 @@ Then the set $A = FLIP(B) = \{ FLIP(x) \;:\; x\in \{0,1\}^n \}$ satisfies $|A|=|
 Since $A$ and $B$ are disjoint events, $\Pr[A] + \Pr[B] \leq 1$. Since they have the same cardinality, they have the same probability and so we get that $2\Pr[B] \leq 1$ or $\Pr[B] \leq 1/2$. (See also [flipaanalysisfig](){.ref}).
 
 
-Claims I and II imply that each of the $T$ iterations of the outer loop succeeds with probability at least $0.5 \cdot \sqrt{3}^{-n/2}$.
-Indeed, by Claim II, the original guess $x$ will satisfy $\Delta(x,x^*) \leq n/2$, and by Claim I, even conditioned on all the history so far, for each of the $S=n/2$ steps we have probability $\geq 1/3$ of being "lucky" and decreasing the distance at one. The chance we will be lucky in all $n/2$ steps is hence at least $(1/3)^{n/2} = \sqrt{3}^{n/2}$.
+Claims I and II imply that each of the $T$ iterations of the outer loop succeeds with probability at least $1/2\cdot\sqrt{3}^{-n}$.
+Indeed, by Claim II, the original guess $x$ will satisfy $\Delta(x,x^*)\leq n/2$ with probability $\Pr[\Delta(x,x^*)\leq n/2]\geq 1/2$, and by Claim I, even conditioned on all the history so far, for each of the $S = n/2$ steps of the inner loop we have probability at least $\geq 1/3$ of being "lucky" and decreasing the distance (i.e.\ the output of $\Delta$) by one.
+The chance we will be lucky in all $n/2$ steps is hence at least $(1/3)^{n/2} = \sqrt{3}^{-n}$.
 
 Since any single iteration of the outer loop succeeds with probability at least $\tfrac{1}{2} \cdot \sqrt{3}^{-n}$, the probability that we never do so in $T=100 \sqrt{3}^{n}$ repetitions is at most $(1-\tfrac{1}{2\sqrt{3}^{n}})^{100\cdot \sqrt{3}^n} \leq (1/e)^{50}$.
 :::

--- a/lec_16_randomized_alg.md
+++ b/lec_16_randomized_alg.md
@@ -275,7 +275,7 @@ Since $A$ and $B$ are disjoint events, $\Pr[A] + \Pr[B] \leq 1$. Since they have
 
 
 Claims I and II imply that each of the $T$ iterations of the outer loop succeeds with probability at least $1/2\cdot\sqrt{3}^{-n}$.
-Indeed, by Claim II, the original guess $x$ will satisfy $\Delta(x,x^*)\leq n/2$ with probability $\Pr[\Delta(x,x^*)\leq n/2]\geq 1/2$, and by Claim I, even conditioned on all the history so far, for each of the $S = n/2$ steps of the inner loop we have probability at least $\geq 1/3$ of being "lucky" and decreasing the distance (i.e.\ the output of $\Delta$) by one.
+Indeed, by Claim II, the original guess $x$ will satisfy $\Delta(x,x^*)\leq n/2$ with probability $\Pr[\Delta(x,x^*)\leq n/2]\geq 1/2$. By Claim I, even conditioned on all the history so far, for each of the $S = n/2$ steps of the inner loop we have probability at least $\geq 1/3$ of being "lucky" and decreasing the distance (i.e.\ the output of $\Delta$) by one.
 The chance we will be lucky in all $n/2$ steps is hence at least $(1/3)^{n/2} = \sqrt{3}^{-n}$.
 
 Since any single iteration of the outer loop succeeds with probability at least $\tfrac{1}{2} \cdot \sqrt{3}^{-n}$, the probability that we never do so in $T=100 \sqrt{3}^{n}$ repetitions is at most $(1-\tfrac{1}{2\sqrt{3}^{n}})^{100\cdot \sqrt{3}^n} \leq (1/e)^{50}$.


### PR DESCRIPTION
I was having trouble understanding the second to last paragraph of the proof of theorem 18.5 (WalkSAT simple analysis). Then I thought I noticed a few typos and sentences that I could make a
little bit clearer. The specific typo that I think I fixed was an incorrect exponent.