### PR TITLE
Added 'by' to the first sentence in the mathy overview.

### DIFF
--- a/acknowledgements.md
+++ b/acknowledgements.md
@@ -53,6 +53,7 @@ If you make a pull request, please also add your name here in the alphabetical o
 * Aditya Mahadevan
 * Kunal Marwaha
 * Christian May
+* Josh Mehr
 * Jacob Meyerson
 * Leon Mlodzian
 * George Moe

--- a/lec_03a_computing_every_function.md
+++ b/lec_03a_computing_every_function.md
@@ -45,7 +45,7 @@ See [computefuncoverviewfig](){.ref} for an outline of the results of this chapt
 
 ::: {.nonmath}
 
-In this chapter we will see our first major result: _every_ finite function can be computed some Boolean circuit (see [circuit-univ-thm](){.ref} and [finitecomputation](){.ref}).
+In this chapter we will see our first major result: _every_ finite function can be computed by some Boolean circuit (see [circuit-univ-thm](){.ref} and [finitecomputation](){.ref}).
 This is sometimes known as the "universality" of $AND$, $OR$, and $NOT$ (and, using the equivalence of [compchap](){.ref}, of $NAND$ as well)
 
 Despite being an important result, [circuit-univ-thm](){.ref} is actually not that hard to prove. [seccomputalternative](){.ref} presents a relatively simple direct proof of this result.

--- a/lec_03a_computing_every_function.md
+++ b/lec_03a_computing_every_function.md
@@ -45,7 +45,7 @@ See [computefuncoverviewfig](){.ref} for an outline of the results of this chapt
 
 ::: {.nonmath}
 
-In this chapter we will see our first major result: _every_ finite function can be computed by some Boolean circuit (see [circuit-univ-thm](){.ref} and [finitecomputation](){.ref}).
+In this chapter, we will see our first major result: _every_ finite function can be computed by some Boolean circuit (see [circuit-univ-thm](){.ref} and [finitecomputation](){.ref}).
 This is sometimes known as the "universality" of $AND$, $OR$, and $NOT$ (and, using the equivalence of [compchap](){.ref}, of $NAND$ as well)
 
 Despite being an important result, [circuit-univ-thm](){.ref} is actually not that hard to prove. [seccomputalternative](){.ref} presents a relatively simple direct proof of this result.


### PR DESCRIPTION
Current sentence:
"In this chapter we will see our first major result: every finite function can be computed some Boolean circuit (see Theorem 4.13 and Big Idea 5)."

Fixed:
"In this chapter we will see our first major result: every finite function can be computed by some Boolean circuit (see Theorem 4.13 and Big Idea 5)."