### PR TITLE
double 'the' in Functions with Infinite domains, Automata, and Regular expressions

### DIFF
--- a/acknowledgements.md
+++ b/acknowledgements.md
@@ -74,6 +74,7 @@ If you make a pull request, please also add your name here in the alphabetical o
 * Peter Schäfer
 * Josh Seides
 * Alaisha Sharma
+* Nathan Sheely
 * Haneul Shin
 * Noah Singer
 * Matthew Smedberg

--- a/lec_04_code_and_data.md
+++ b/lec_04_code_and_data.md
@@ -431,7 +431,7 @@ Specifically, if `Table` is a variable holding this data structure, then we assu
 
 * `GET(Table,i)` which retrieves the bit corresponding to `i` in `Table`. The value of `i` is assumed to be an integer in $[t]$.
 
-* `Table = UPDATE(Table,i,b)` which updates `Table` so the the bit  corresponding to `i` is now set to `b`. The value of `i` is assumed to be an integer in $[t]$ and `b` is a bit in $\{0,1\}$.
+* `Table = UPDATE(Table,i,b)` which updates `Table` so the bit  corresponding to `i` is now set to `b`. The value of `i` is assumed to be an integer in $[t]$ and `b` is a bit in $\{0,1\}$.
 
 
 

--- a/lec_05_infinite.md
+++ b/lec_05_infinite.md
@@ -939,7 +939,7 @@ In all these cases the conditions of the lemma are satisfied simply because ther
 
 We now prove the __inductive step__.   Let $e$ be a regular expression with $n>1$ symbols.
 We set $n_0=2n$ and let $w\in \Sigma^*$ be a string satisfying $|w|>n_0$.
-Since $e$ has more than one symbol, it has  one of the  the forms __(a)__ $e' | e''$, __(b)__, $(e')(e'')$, or __(c)__ $(e')^*$ where in all these cases the subexpressions $e'$ and $e''$ have fewer symbols than $e$ and hence satisfy the induction hypothesis.
+Since $e$ has more than one symbol, it has  one of the forms __(a)__ $e' | e''$, __(b)__, $(e')(e'')$, or __(c)__ $(e')^*$ where in all these cases the subexpressions $e'$ and $e''$ have fewer symbols than $e$ and hence satisfy the induction hypothesis.
 
 
 In the case __(a)__, every string $w$ matched by $e$ must be matched by either $e'$ or $e''$.

--- a/lec_05_infinite.md
+++ b/lec_05_infinite.md
@@ -60,7 +60,7 @@ def XOR(X):
        Outputs 1 if the number of 1's is odd and outputs 0 otherwise'''
     result = 0
     for i in range(len(X)):
-        result += X[i] % 2
+        result = (result + X[i]) % 2
     return result
 ```
 
@@ -245,7 +245,7 @@ def XOR(X):
        Outputs 1 if the number of 1's is odd and outputs 0 otherwise'''
     result = 0
     for i in range(len(X)):
-        result += X[i] % 2
+        result = (result + X[i]) % 2
     return result
 ```
 

--- a/lec_10_efficient_alg.md
+++ b/lec_10_efficient_alg.md
@@ -240,7 +240,7 @@ By the above we know that there is a polynomial-time algorithm $A$ that on input
 2. $B$ returns the minimum of $k_{s,t}$ over all distinct pairs $s,t$
 
 The running time of $B$ will be $O(n^2)$ times the running time of $A$ and hence polynomial time.
-Moreover, if the the global minimum cut is $S$, then when $B$ reaches an iteration with $s\in S$ and $t\not\in S$ it will obtain the value of this cut, and hence the value output by $B$ will be the value of the global minimum cut.
+Moreover, if the global minimum cut is $S$, then when $B$ reaches an iteration with $s\in S$ and $t\not\in S$ it will obtain the value of this cut, and hence the value output by $B$ will be the value of the global minimum cut.
 
 The above is our first example of a _reduction_ in the context of polynomial-time algorithms.
 Namely, we reduced the task of computing the global minimum cut to the task of computing minimum $s,t$ cuts.

--- a/lec_17_model_rand.md
+++ b/lec_17_model_rand.md
@@ -337,7 +337,7 @@ Then by [ampeq](){.eqref}, $\Pr[B_x] \leq 0.1\cdot 2^{-n}$ for every $x \in \{0,
 Since there are $2^n$ many such $x$'s, by the union bound we see that the probability that the _union_ of the events $\{ B_x \}_{x\in \{0,1\}^n}$ is at most $0.1$.
 This means that if we choose $r \sim \{0,1\}^m$, then with probability at least $0.9$ it will be the case that for _every_ $x\in \{0,1\}^n$, $F(x)=P'(x;r)$.
 (Indeed, otherwise the event $B_x$ would hold for some $x$.)
-In particular, because of the mere fact that the the probability of $\cup_{x \in \{0,1\}^n} B_x$ is smaller than $1$, this means that _there exists_ a particular $r^* \in \{0,1\}^m$ such that
+In particular, because of the mere fact that the probability of $\cup_{x \in \{0,1\}^n} B_x$ is smaller than $1$, this means that _there exists_ a particular $r^* \in \{0,1\}^m$ such that
 
 $$P'(x;r^*)=F(x) \label{hardwirecorrecteq}
 $$


### PR DESCRIPTION
Chapter: Functions with Infinite domains, Automata, and Regular expressions

Section: Limitations of regular expressions and the pumping lemma

In the line

 Since $e$ has more than one symbol, it has one of the the forms (a) $e' | e''$, (b), $(e')(e'')$, or (c) $(e')^$ where in all these cases the subexpressions $e'$ and $e''$ have fewer symbols than $e$ and hence satisfy the induction hypothesis.

repeated the word 'the' twice in a row.

Nathan Sheely