### PR TITLE
Small typos in Exercise 1.12

### DIFF
--- a/acknowledgements.md
+++ b/acknowledgements.md
@@ -99,6 +99,7 @@ If you make a pull request, please also add your name here in the alphabetical o
 * Josh Zelinsky
 * Fred Zhang
 * Grace Zhang
+* Alex Zhao
 * Jessica Zhu
 * Kai Ma
 

--- a/lec_00_1_math_background.md
+++ b/lec_00_1_math_background.md
@@ -1166,9 +1166,9 @@ b. $F(n)=n$, $G(n)=\sqrt{n}$.
 
 c. $F(n)=n\log n$, $G(n)=2^{(\log (n))^2}$.
 
-d. $F(n)=\sqrt{n}$, $G(n)=2^{\sqrt{\log n}}$
+d. $F(n)=\sqrt{n}$, $G(n)=2^{\sqrt{\log n}}$.
 
-e. $F(n) = \binom{n}{\ceil{0.2 n}}$ ,  $G(n) = 2^{0.1 n}$ (where $\binom{n}{k}$ is the number of $k$-sized subsets of a set of size $n$) and $g(n) = 2^{0.1 n}$. See footnote for hint.^[one way to do this is to use [Stirling's approximation for the factorial function.](https://goo.gl/cqEmS2).]
+e. $F(n) = \binom{n}{\ceil{0.2 n}}$, $G(n) = 2^{0.1 n}$ (where $\binom{n}{k}$ is the number of $k$-sized subsets of a set of size $n$). See footnote for hint.^[One way to do this is to use [Stirling's approximation for the factorial function](https://goo.gl/cqEmS2).]
 :::
 
 ::: {.exercise}


### PR DESCRIPTION
Fixes a few small inconsistencies in Exercise 1.12.
- Adds a period at the end of part (d) to match the other parts.
- `and g(n) = 2^{0.1 n}` seems to be repeated in part (e), which I've deleted.
- Capitalize the footnote.
- Remove the extra period in the footnote.