### PR TITLE
Update lec_01_introduction.md

### DIFF
--- a/lec_01_introduction.md
+++ b/lec_01_introduction.md
@@ -112,7 +112,7 @@ We ask some questions that were already pondered by the Babylonians, such as "wh
 
 
 
-::: {.remark title="Specification, implementation and analysis of algorithms." #implspecanarem}
+::: {.remark title="Specification, implementation, and analysis of algorithms." #implspecanarem}
 A full description of an algorithm has three components:
 
 * __Specification__: __What__ is the task that the algorithm performs (e.g., multiplication in the case of [naivemultalg](){.ref} and [gradeschoolalg](){.ref}.)


### PR DESCRIPTION
Missing Oxford comma? I've noticed in some spots, there is an oxford comma (Chapter 2, bottom of 84 "matrices, images, and graphs", and in some, there isn't (here). Is there a format you prefer?