### PR TITLE
Update lec_00_1_math_background.md

### DIFF
--- a/lec_00_1_math_background.md
+++ b/lec_00_1_math_background.md
@@ -763,7 +763,7 @@ That is, to prove the statement $X$, we might first prove statements $X_1$,$X_2$
 
 __Proofs by case distinction:__ This is a special case of the above, where to prove a statement $X$ we split into several cases $C_1,\ldots,C_k$, and prove that __(a)__ the cases are _exhaustive_, in the sense that _one_ of the cases $C_i$  must happen and __(b)__ go one by one and prove that each one of the cases $C_i$ implies the result $X$ that we are after.
 
-__Proofs by induction:__ We discuss induction and give an example in [inductionsec](){.ref} below. We can think of such proofs as a variant of the above, where we have an unbounded number of intermediate claims $X_0,X_2,\ldots,X_k$, and we prove that $X_0$ is true, as well as that $X_0$ implies $X_1$, and that $X_0  \wedge X_1$ implies $X_2$, and so on and so forth.
+__Proofs by induction:__ We discuss induction and give an example in [inductionsec](){.ref} below. We can think of such proofs as a variant of the above, where we have an unbounded number of intermediate claims $X_0,X_1,X_2,\ldots,X_k$, and we prove that $X_0$ is true, as well as that $X_0$ implies $X_1$, and that $X_0  \wedge X_1$ implies $X_2$, and so on and so forth.
 The website for CMU course 15-251 contains a [useful handout](http://www.cs.cmu.edu/~arielpro/15251f17/notes/induction-pitfalls.pdf) on potential pitfalls when making proofs by induction.
 
 


### PR DESCRIPTION
In Ch 1: Mathematical Background 1.53 Patterns in Proofs, under the section about Proofs by induction when listing hypothetical unbounded claims, the list jumps from X_0 to X_2 and excludes X_1.