### PR TITLE
Correct undefined variable in AON-CIRC specification

### DIFF
--- a/acknowledgements.md
+++ b/acknowledgements.md
@@ -64,6 +64,7 @@ If you make a pull request, please also add your name here in the alphabetical o
 * Jacob Meyerson
 * Leon Mlodzian
 * George Moe
+* Kian Moretz
 * Todd Morrill
 * Glenn Moss
 * Haley Mulligan

--- a/lec_03_computation.md
+++ b/lec_03_computation.md
@@ -712,7 +712,7 @@ Since then, (adjusted versions of) this so-called "Moore's law" have been runnin
 ### Logical gates from transistors
 
 We can use transistors to implement various Boolean functions such as $AND$, $OR$, and $NOT$.
-For each a two-input gate $G:\{0,1\}^2 \rightarrow \{0,1\}$,  such an implementation would be a system with two input wires $x,y$ and one output wire $z$, such that if we identify high voltage with "$1$" and low voltage with "$0$", then the wire  $z$ will equal to "$1$" if and only if applying $G$ to the values of the wires $x$ and $y$ is $1$ (see [logicgatestransistorsfig](){.ref} and [transistor-nand-fig](){.ref}).
+For each a two-input gate $G:\{0,1\}^2 \rightarrow \{0,1\}$,  such an implementation would be a system with two input wires $x,y$ and one output wire $z$, such that if we identify high voltage with "$1$" and low voltage with "$0$", then the wire  $z$ will be equal to "$1$" if and only if applying $G$ to the values of the wires $x$ and $y$ is $1$ (see [logicgatestransistorsfig](){.ref} and [transistor-nand-fig](){.ref}).
 This means that if there exists a AND/OR/NOT circuit to compute a function $g:\{0,1\}^n \rightarrow \{0,1\}^m$, then we can compute $g$ in the physical world using transistors as well.
 
 ![Implementing logical gates using transistors. Figure taken from [Rory Mangles' website](http://www.northdownfarm.co.uk/rory/tim/basiclogic.htm).](../figure/dtl_logic.png){#logicgatestransistorsfig   .margin  }

--- a/lec_03_computation.md
+++ b/lec_03_computation.md
@@ -542,7 +542,7 @@ Luckily, the AON-CIRC programming language is simple enough that we can define i
 An AON-CIRC program is a sequence of strings, which we call "lines", satisfying the following conditions: 
 
 
-* Every line has one of the following forms: `foo = AND(bar,blah)`,  `foo = OR(bar,baz)`, or  `foo = NOT(bar)` where `foo`, `bar` and `baz` are _variable identifiers_. (We follow the common [programming languages convention](https://goo.gl/QyHa3b)  of using names such as `foo`, `bar`, `baz` as stand-ins for generic identifiers.) The line `foo = AND(bar,baz)` corresponds to the operation of assigning to the variable `foo` the logical AND of the values of the variables `bar` and `baz`. Similarly  `foo = OR(bar,baz)` and `foo = NOT(bar)` correspond to the logical OR and logical NOT operations. 
+* Every line has one of the following forms: `foo = AND(bar,baz)`,  `foo = OR(bar,baz)`, or  `foo = NOT(bar)` where `foo`, `bar` and `baz` are _variable identifiers_. (We follow the common [programming languages convention](https://goo.gl/QyHa3b)  of using names such as `foo`, `bar`, `baz` as stand-ins for generic identifiers.) The line `foo = AND(bar,baz)` corresponds to the operation of assigning to the variable `foo` the logical AND of the values of the variables `bar` and `baz`. Similarly  `foo = OR(bar,baz)` and `foo = NOT(bar)` correspond to the logical OR and logical NOT operations. 
 
 
 * A _variable identifier_ in the AON-CIRC programming language can be any combination of letters, numbers,  underscores, and brackets. There are two special types of variables:

--- a/lec_03a_computing_every_function.md
+++ b/lec_03a_computing_every_function.md
@@ -717,7 +717,7 @@ We define $SIZE_{n,m}(s)$ to be the set of functions mapping $n$ bits to $m$ bit
 Formally, the definition is as follows:
 
 > ### {.definition title="Size class of functions" #sizedef}
-For every natural numbers $n,m,s$, let $SIZE_{n,m}(s)$ denote the set of all functions $f:\{0,1\}^n \rightarrow \{0,1\}^m$ such that there NAND circuit of at most $s$ gates computing $f$.
+For all natural numbers $n,m,s$, let $SIZE_{n,m}(s)$ denote the set of all functions $f:\{0,1\}^n \rightarrow \{0,1\}^m$ such that there exists a NAND circuit of at most $s$ gates computing $f$.
 We denote by $SIZE_n(s)$ the set $SIZE_{n,1}(s)$.
 For every integer $s \geq 1$, we let $SIZE(s) = \cup_{n,m} SIZE_{n,m}(s)$ be the set of all functions $f$ for which there exists a NAND circuit of at most $s$ gates that compute $f$.
 


### PR DESCRIPTION
The AON-CIRC specification in chapter 3 used the variable name `blah` in one location, but `baz` in all others, and only specified `baz` as an arbitrary variable name in the explanation of these definitions. (Other places in the chapter seem to use `blah` more consistently - another editorial choice would be to replace the instances of `baz` here with `blah`.)

I also made a minor grammatical correction (a wire can "be equal to" something, but can't "equal to" it), and some changes to Definition 4.18 in chapter 4 ("for every natural numbers" -> "for all natural numbers", "there NAND circuit" -> "there exists a NAND circuit").