### PR TITLE
fix: Week 1 Reading Typos

### DIFF
--- a/acknowledgements.md
+++ b/acknowledgements.md
@@ -12,6 +12,7 @@ If you make a pull request, please also add your name here in the alphabetical o
 * Emily Chan
 * Christy Cheng
 * Michelle Chiang
+* Gabriel Chiong
 * Daniel Chiu
 * Chi-Ning Chou
 * Michael Colavita

--- a/lec_01_introduction.md
+++ b/lec_01_introduction.md
@@ -236,7 +236,7 @@ If $x,y$ are integers of at most $n$ digits,  [karatsubaalg](){.ref} will take $
 ::: {.proof data-ref="karatsubaefficient"}
 [karatsubafig](){.ref} illustrates the idea behind the proof, which we only sketch here, leaving filling out the details as [karatsuba-ex](){.ref}.
 The proof is again by induction. We define $T(n)$ to be the maximum number of steps that [karatsubaalg](){.ref} takes on inputs of length at most $n$.
-Since in the base case $n\leq 2$, [karatsuba-ex](){.ref} performs a constant number of computation, we know that $T(2) \leq c$ for some constant $c$ and for $n>2$, it satisfies the recursive equation
+Since in the base case $n\leq 4$, [karatsuba-ex](){.ref} performs a constant number of computation, we know that $T(4) \leq c$ for some constant $c$ and for $n>4$, it satisfies the recursive equation
 $$
 T(n) \leq 3T(\floor{n/2}+1) + c' n \label{eqkaratsubarecursion}
 $$

--- a/lec_02_representation.md
+++ b/lec_02_representation.md
@@ -136,7 +136,7 @@ $$NtS(n) = \begin{cases}
             NtS(\floor{n/2}) parity(n) & n>1
 \end{cases} \label{ntseq}$$
 where $parity:\N \rightarrow \{0,1\}$  is the function defined as $parity(n)=0$ if $n$ is even and $parity(n)=1$ if $n$ is odd, and as usual, for strings $x,y \in \{0,1\}^*$, $xy$ denotes the concatenation of $x$ and $y$.
-The function $NtS$ is defined _recursively_: for every $n>0$ we define $rep(n)$ in terms of the representation of the smaller number $\floor{n/2}$.
+The function $NtS$ is defined _recursively_: for every $n>1$ we define $rep(n)$ in terms of the representation of the smaller number $\floor{n/2}$.
 It is also possible to define $NtS$ non-recursively, see [binaryrepex](){.ref}.
 
 Throughout most of this book, the particular choices of representation of numbers as binary strings would not matter much: we just need to know that such a representation exists.
@@ -653,7 +653,7 @@ Indeed, for $i=0,1,\ldots,m-1$ let us "mark" the element $t_j=E(s_i)$ in $T$.
 If $t_j$ was marked before, then we have found two objects in $S$ mapping to the same element $t_j$.
 Otherwise, since $T$ has $m$ elements,  when we get to $i=m-1$ we mark all the objects in $T$.
 Hence, in this case, $E(s_m)$ must map to an element that was already marked before. 
-(This observation is sometimes known as the "Pigeon Hole Principle": the principle that if you have a pigeon coop with $m$ holes and $k>m$ pigeons, then there must be two pigeons in the same hole.)
+(This observation is sometimes known as the "Pigeonhole Principle": the principle that if you have a pigeon coop with $m$ holes and $k>m$ pigeons, then there must be two pigeons in the same hole.)
 
 ### Prefix-free encoding { #prefixfreesec }
 


### PR DESCRIPTION
Fixes:
- Algorithm 0.4 - Karatsuba multiplication, line 2 of the implementation uses `n <= 4` as the base case, which is not reflected consistently in the proof of Lemma 0.6.
- The base case for `NtS` (Equation 2.1) is defined with base cases `n = 0` and `n = 1`. The recursive case only occurs kicks in when `n > 1`.
- "Pigeonhole Principle" rather than "Pigeon Hole Principle" is used in various other sources in discrete mathematics such as [LLM's MCS](https://courses.csail.mit.edu/6.042/spring18/mcs.pdf) Section 15.8, [Jim Aspen's Notes](http://www.cs.yale.edu/homes/aspnes/classes/202/notes.pdf) Section 11.1.3.2, and [Wikipedia](https://en.wikipedia.org/wiki/Pigeonhole_principle).