### PR TITLE
Chapter 6,8,9 typos

### DIFF
--- a/acknowledgements.md
+++ b/acknowledgements.md
@@ -36,6 +36,7 @@ If you make a pull request, please also add your name here in the alphabetical o
 * Alexander Golovnev
 * Sayan Goswami
 * Maxwell Grozovsky
+* Kenneth Gu
 * Michael Haak
 * Rebecca Hao
 * Lucia Hoerr

--- a/lec_05_infinite.md
+++ b/lec_05_infinite.md
@@ -583,7 +583,7 @@ Eventually (when they have size $1$) then they must correspond to the non-recurs
 Correspondingly, the recursive calls made in [regexpmatchalg](){.ref} always correspond to a shorter expression or (in the case of an expression of the form  $(e')^*$) a shorter input string.
 Thus, we can prove the correctness of [regexpmatchalg](){.ref} on inputs of the form $(e,x)$ by induction over $\min \{ |e|, |x| \}$. 
 The base case is when either $x=""$ or $e$ is a single alphabet symbol, $""$ or $\emptyset$.
-In the case the expression is of the forrm $e=(e'|e'')$ or $e=(e')(e'')$, we make recursive calls with the shorter expressions $e',e''$.
+In the case the expression is of the form $e=(e'|e'')$ or $e=(e')(e'')$, we make recursive calls with the shorter expressions $e',e''$.
 In the case the expression is of the form $e=(e')^*$, we make recursive calls with either a shorter string $x$ and the same expression,
 or with the shorter expression $e'$ and a string $x'$ that is equal in length or shorter than $x$.
 

--- a/lec_07_other_models.md
+++ b/lec_07_other_models.md
@@ -935,7 +935,7 @@ Showing __(2)__ essentially amounts to simulating a Turing machine (or writing a
 We only sketch the proof. The "if" direction is simple. As mentioned above, evaluating λ expressions basically amounts to "search and replace". It is also a fairly straightforward programming exercise to implement all the above basic operations in an imperative language such as Python or C, and using the same ideas we can do so in NAND-RAM as well, which we can then transform to a NAND-TM program.
 
 For the "only if" direction we need to simulate a Turing machine using a λ expression.
-We will do so by first showing that showing for every Turing machine $M$ a λ expression to compute the next-step function $NEXT_M:\overline{\Sigma}^* \rightarrow \overline{\Sigma}^*$ that maps a configuration of $M$ to the next one (see [turingmachinesconfigsec](){.ref}).
+We will do so by first showing for every Turing machine $M$ a λ expression to compute the next-step function $NEXT_M:\overline{\Sigma}^* \rightarrow \overline{\Sigma}^*$ that maps a configuration of $M$ to the next one (see [turingmachinesconfigsec](){.ref}).
 
 A configuration of $M$ is a string $\alpha \in \overline{\Sigma}^*$ for a finite set $\overline{\Sigma}$. We can encode every symbol $\sigma \in \overline{\Sigma}$ by a finite string $\{0,1\}^\ell$, and so we will encode a configuration $\alpha$ in the  λ calculus as a list $\langle \alpha_0, \alpha_1, \ldots, \alpha_{m-1}, \bot \rangle$ where $\alpha_i$ is an $\ell$-length string (i.e., an $\ell$-length  list of $0$'s and $1$'s) encoding a symbol in $\overline{\Sigma}$.
 

--- a/lec_08_uncomputability.md
+++ b/lec_08_uncomputability.md
@@ -163,7 +163,7 @@ On input a transition table $\delta$ this program will simulate the correspondin
 The above does not prove the theorem as stated, since we need to show a _Turing machine_ that computes $EVAL$ rather than a Python program.
 With enough effort, we can translate this Python code line by line to a Turing machine.
 However, to prove the theorem we don't need to do this, but can use our "eat the cake and have it too" paradigm.
-That is, while we need to evaluate a Turing machine, in writing the code for the interpreter we are allowed to use a richer model such as NAND-RAM since it is equivalent in power to Turing machines per  [RAMTMequivalencethm](){.ref}).
+That is, while we need to evaluate a Turing machine, in writing the code for the interpreter we are allowed to use a richer model such as NAND-RAM since it is equivalent in power to Turing machines per  [RAMTMequivalencethm](){.ref}.
 
 
 Translating the above Python code to NAND-RAM is truly straightforward.


### PR DESCRIPTION
- Fixed typo "forrm" in chapter 6 (lec_05)
- Removed extra "that showing" in "by first showing that showing..." in chapter 8 (lec_07)
- Removed extra right parenthesis at end of sentence (lec_08)
- Added name to acknowledgements