### PR TITLE
Fixing typo in figure 6.4 to explain mapping to new state not symbol

### DIFF
--- a/lec_05_infinite.md
+++ b/lec_05_infinite.md
@@ -356,7 +356,7 @@ See also [DFAzerooneexecfig](){.ref}, which depicts the execution of this DFA on
 
 ![A DFA that outputs $1$ only on inputs $x\in \{0,1\}^*$ that are a concatenation of zero or more copies of $010$.
 The state $0$ is both the starting state and the only accepting state.
-The table denotes the transition function of $T$, which maps the current state and symbol read to the new symbol.](../figure/DFA010a.png){#dfazeroonefig  .margin }
+The table denotes the transition function of $T$, which maps the current state and symbol read to the new state.](../figure/DFA010a.png){#dfazeroonefig  .margin }
 
 
 ### Anatomy of an automaton (finite vs. unbounded)

--- a/lec_11_running_time.md
+++ b/lec_11_running_time.md
@@ -40,7 +40,7 @@ As mentioned in Edmond's quote in [chapefficient](){.ref}, the difference betwee
 
 ::: {.nonmath}
 In this chapter we formally define what it means for a function to be computable in a certain number of steps.
-As discussed in [chapefficient](){.ref}, running time is not a number, rather what we care about is the _scaling behevaiour_ 
+As discussed in [chapefficient](){.ref}, running time is not a number, rather what we care about is the _scaling behaviour_ 
 of the number of steps as the input size grows.
 We can use either Turing machines or RAM machines to give such a formal definition - it turns out that this doesn't make a difference at the resolution we care about.
 We make several important definitions and prove some important theorems in this chapter.


### PR DESCRIPTION
I believe that the transition function here maps current state and symbol read to new state, not new symbol; based on the table alongside. 