### PR TITLE
Fix typos in chapter 13/14

### DIFF
--- a/lec_11_running_time.md
+++ b/lec_11_running_time.md
@@ -378,7 +378,7 @@ There exists a NAND-RAM program $U$ satisfying the following:
 
 1. _($U$ is a universal NAND-RAM program.)_ For every NAND-RAM program $P$ and input $x$,  $U(P,x)=P(x)$ where by $U(P,x)$ we denote the output of $U$ on a string encoding the pair $(P,x)$.
 
-2. _($U$ is efficient.)_ There are some constants $a,b$ such that for every NAND-RAM program $P$, if $P$ halts on input $x$ after most $T$ steps, then $U(P,x)$ halts after at most $C\cdot T$ steps where $C \leq a |P|^b$. 
+2. _($U$ is efficient.)_ There are some constants $a,b$ such that for every NAND-RAM program $P$, if $P$ halts on input $x$ after at most $T$ steps, then $U(P,x)$ halts after at most $C\cdot T$ steps where $C \leq a |P|^b$. 
 :::
 
 

--- a/lec_12_NP.md
+++ b/lec_12_NP.md
@@ -471,7 +471,7 @@ are a vertex cover.](../figure/vertex_cover.png){#vertexcoverfig .margin }
 
 
 ::: {.solution data-ref="vertexcoverex"}
-The key observation is that if $S \subseteq V$ is a vertex cover that touches all vertices, then there is no edge $e$ such that both $s$'s endpoints
+The key observation is that if $S \subseteq V$ is a vertex cover that touches all vertices, then there is no edge $e$ such that both $e$'s endpoints
 are in the set $\overline{S} = V \setminus S$, and vice versa.
 In other words, $S$ is a vertex cover if and only if $\overline{S}$ is an independent set.
 Since the size of $\overline{S}$ is $|V|-|S|$, we see that the polynomial-time map $R(G,k)=(G,n-k)$ (where $n$ is the number of vertices of $G$) satisfies that $VC(R(G,k))= ISET(G,k)$ which means that it is a reduction from independent set to vertex cover.


### PR DESCRIPTION
Change "after most' to "after at most" on page 429 (chapter 13) and change "s" to "e" on page 465 (chapter 14).