### PR TITLE
Typo in Chapter 13 on time hierarchy theorem

### DIFF
--- a/acknowledgements.md
+++ b/acknowledgements.md
@@ -121,4 +121,5 @@ If you make a pull request, please also add your name here in the alphabetical o
 * Alex Zhao
 * Jessica Zhu
 * Luke Bailey
+* Zijian(Carl) Ma
 

--- a/lec_11_running_time.md
+++ b/lec_11_running_time.md
@@ -542,7 +542,7 @@ We show why this statement follows from the time hierarchy theorem, but it can b
 We need to show that there exists $F \in \mathbf{EXP} \setminus \mathbf{P}$.
 Let $T(n) = n^{\log n}$ and $T'(n) = n^{\log n / 2}$.
 Both are nice functions.
-Since $T(n)/T'(n) = \omega(\log n)$, by [time-hierarchy-thm](){.ref} there exists some $F$ in $TIME(T(n))/TIME(T(n))$.
+Since $T(n)/T'(n) = \omega(\log n)$, by [time-hierarchy-thm](){.ref} there exists some $F$ in $TIME(T(n))/TIME(T'(n))$.
 Since for sufficiently large $n$, $2^n > n^{\log n}$,  $F \in TIME(2^n) \subseteq \mathbf{EXP}$.
 On the other hand, $F \not\in \mathbf{P}$. Indeed, suppose otherwise that there was a constant $c>0$ and a  Turing machine computing $F$ on $n$-length input in at most $n^c$ steps for all sufficiently large $n$. Then since for $n$ large enough $n^c < n^{\log n/2}$, it would have followed that $F \in TIME(n^{\log n /2})$ contradicting our choice of $F$.
 :::

--- a/lec_11_running_time.md
+++ b/lec_11_running_time.md
@@ -542,7 +542,7 @@ We show why this statement follows from the time hierarchy theorem, but it can b
 We need to show that there exists $F \in \mathbf{EXP} \setminus \mathbf{P}$.
 Let $T(n) = n^{\log n}$ and $T'(n) = n^{\log n / 2}$.
 Both are nice functions.
-Since $T(n)/T'(n) = \omega(\log n)$, by [time-hierarchy-thm](){.ref} there exists some $F$ in $TIME(T'(n)) \subsetneq TIME(T(n))$.
+Since $T(n)/T'(n) = \omega(\log n)$, by [time-hierarchy-thm](){.ref} there exists some $F$ in $TIME(T(n))/TIME(T(n))$.
 Since for sufficiently large $n$, $2^n > n^{\log n}$,  $F \in TIME(2^n) \subseteq \mathbf{EXP}$.
 On the other hand, $F \not\in \mathbf{P}$. Indeed, suppose otherwise that there was a constant $c>0$ and a  Turing machine computing $F$ on $n$-length input in at most $n^c$ steps for all sufficiently large $n$. Then since for $n$ large enough $n^c < n^{\log n/2}$, it would have followed that $F \in TIME(n^{\log n /2})$ contradicting our choice of $F$.
 :::


### PR DESCRIPTION
The typo here is that we should have chosen FF in TIME(T(n)) \setminus TIME(T'(n))TIME(T(n))∖TIME(T ′(n))