### PR TITLE
Change reduction direction in ZEROFUNC uncomputability proof

### DIFF
--- a/acknowledgements.md
+++ b/acknowledgements.md
@@ -121,4 +121,5 @@ If you make a pull request, please also add your name here in the alphabetical o
 * Alex Zhao
 * Jessica Zhu
 * Luke Bailey
+* Catherine Huang
 


### PR DESCRIPTION
For the ZEROFUNC uncomputability proof, I believe the reduction is in the other direction (reducing _from_ HALTONZERO).