### PR TITLE
Typo fix: swap EQUAL and \neg EQUAL in size hierarchy proof

### DIFF
--- a/lec_04_code_and_data.md
+++ b/lec_04_code_and_data.md
@@ -229,7 +229,7 @@ f_i(x) = \begin{cases} b & x=x^* \\ f_{i-1}(x) & x \neq x^*
 $$
 or in other words
 $$
-f_i(x) = f_{i-1}(x) \wedge EQUAL(x^*,x) \; \vee \;  b \wedge \neg EQUAL(x^*,x)
+f_i(x) = f_{i-1}(x) \wedge \neg EQUAL(x^*,x) \; \vee \;  b \wedge EQUAL(x^*,x)
 $$
 where $EQUAL:\{0,1\}^{2n} \rightarrow \{0,1\}$ is the function that maps $x,x' \in \{0,1\}^n$ to $1$ if they are equal and to $0$ otherwise.
 Since (by our choice of $i$), $f_{i-1}$ can be computed using at most $s$ gates and (as can be easily verified) that $EQUAL \in SIZE_n(9n)$,


### PR DESCRIPTION
Typo in chapter "Code and Data" in proof of Size Hierarchy theorem, typo is in the logical relation after "or in other words" where I believe that logical relation is not correct for the piecewise function defined right above it. In particular, the EQUAL and \neg EQUAL should be swapped. 