### PR TITLE
fix: Misc improvements for chapter 7,8,9,12,13

### DIFF
--- a/lec_06_loops.md
+++ b/lec_06_loops.md
@@ -583,7 +583,7 @@ The idea behind the NAND-TM program to simulate $M$ is to:
 Given the above, we can write code of the form:
 
 
-`state_`$0$ $\ldots$ `state_`$\ell-1$, `Tape_`$0$`[i]`$\ldots$ `Tape_`$\ell'-1$`[i]`, `dir0`,`dir1` $\leftarrow$ `TRANSITION(` `state_`$0$ $\ldots$ `state_`$\ell-1$, `Tape_`$0$`[i]`$\ldots$ `Tape_`$\ell'-1$`[i]`, `dir0`,`dir1` `)`
+`state_`$0$ $\ldots$ `state_`$\ell-1$, `Tape_`$0$`[i]`$\ldots$ `Tape_`$\ell'-1$`[i]`, `dir0`,`dir1` $\leftarrow$ `TRANSITION(` `state_`$0$ $\ldots$ `state_`$\ell-1$, `Tape_`$0$`[i]`$\ldots$ `Tape_`$\ell'-1$`[i]` `)`
 
 `MODANDJUMP(dir0,dir1)`
 

--- a/lec_07_other_models.md
+++ b/lec_07_other_models.md
@@ -498,7 +498,7 @@ To turn the above ideas into a rigorous proof (and even statement!) of [onedimca
 This notion will be useful for us in later chapters as well.
 
 
-![A _configuration_ of a Turing machine $M$ with alphabet $\Sigma$ and state space $[k]$ encodes the state of $M$ at a particular step in its execution as a string $\alpha$ over the alphabet $\overline{\Sigma} = \Sigma \times (\{\cdot \} \times [k])$. The string is of length $t$ where $t$ is such that $M$'s tape contains $\varnothing$ in all positions $t$ and larger and $M$'s head is in a position smaller than $t$.
+![A _configuration_ of a Turing machine $M$ with alphabet $\Sigma$ and state space $[k]$ encodes the state of $M$ at a particular step in its execution as a string $\alpha$ over the alphabet $\overline{\Sigma} = \Sigma \times (\{\cdot \} \cup [k])$. The string is of length $t$ where $t$ is such that $M$'s tape contains $\varnothing$ in all positions $t$ and larger and $M$'s head is in a position smaller than $t$.
 If $M$'s head is in the $i$-th position, then for $j \neq i$, $\alpha_j$ encodes the value of the $j$-th cell of $M$'s tape, while $\alpha_i$ encodes both this value as well as the current state of $M$.
 If the machine writes the value $\tau$, changes state to $t$, and moves right, then in the next configuration will contain at position $i$ the value  $(\tau,\cdot)$ and at position $i+1$ the value $(\alpha_{i+1},t)$.](../figure/turingmachineconf.png){#turingconfigfig   }
 

--- a/lec_07_other_models.md
+++ b/lec_07_other_models.md
@@ -551,7 +551,7 @@ __Completing the proof of  [onedimcathm](){.ref}.__ We can now restate [onedimca
 
 ::: {.theorem title="One dimensional automata are Turing complete (formal statement)" #onedimcathmformal}
 For every Turing machine $M$, if we denote by $\overline{\Sigma}$ the alphabet of its configuration strings, then there is a one-dimensional cellular automaton $r$ over the alphabet $\overline{\Sigma}^*$  such that
-$$\left( NEXT_M(\alpha) \right)  = NEXT_r \left( \alpha \right)$$
+$$ NEXT_M \left( \alpha \right)  = NEXT_r \left( \alpha \right)$$
 for every configuration $\alpha \in \overline{\Sigma}^*$ of $M$ (again using the convention that we consider $\alpha_i=\varnothing$ if $i$ is "out of bounds").
 :::
 

--- a/lec_12_NP.md
+++ b/lec_12_NP.md
@@ -362,7 +362,7 @@ More concretely, if the instance has such an equation then we can know for sure 
 Our reduction is described in [zeroonetossumnalg ](){.ref}. 
 On input an instance $E = \{ e_t \}_{t=1}^m$ of $01EQ$ over $n$ variables $x_0,\ldots,x_{n-1}$, we output an $SSUM$ instance $y_0,\ldots,y_{n-1},T$ computed as follows:
 
-* $y_i = \sum_{t=0}^{m-1} B^t v^t_i$ where $v^t_i$ equals $1$ if the variable $x_i$ appears in the equation $e_t$ and equals $0$ otherwise. The number $B$ is set to be $2n$ (any numb er larger than $n$ would work.)
+* $y_i = \sum_{t=0}^{m-1} B^t v^i_t$ where $v^i_t$ equals $1$ if the variable $x_i$ appears in the equation $e_t$ and equals $0$ otherwise. The number $B$ is set to be $2n$ (any numb er larger than $n$ would work.)
 
 * $T = \sum_{t=0}^{m-1} B^t b_t$ where $b_t$ is the integer on the right-hand side of the equation $e_t$.
 

--- a/lec_13_Cook_Levin.md
+++ b/lec_13_Cook_Levin.md
@@ -138,7 +138,7 @@ INPUT: 3CNF formula $\varphi$ on $k$ variables and with $m$ clauses, string $w \
 OUTPUT: $1$ iff $w$ satisfies $\varphi$ 
 
 For{$j \in [m]$}
-   Let $\ell_1 \vee \ell_2 \vee \ell_j$ be the $j$-th clause of $\varphi$ 
+   Let $\ell_1 \vee \ell_2 \vee \ell_3$ be the $j$-th clause of $\varphi$ 
    If{$w$ violates all three literals}
      return $0$
    Endif
@@ -367,7 +367,7 @@ The proof is a little bit technical but ultimately follows quite directly from t
 
 ::: {.proof data-ref="nand-thm"}
 Let $F \in \mathbf{NP}$.
-To prove [nand-thm](){.ref} we need to give a polynomial-time computable function that will map every $x^* \in \{0,1\}^*$ to a NAND-CIRC program $Q$ such that $F(x)=NANDSAT(Q)$.
+To prove [nand-thm](){.ref} we need to give a polynomial-time computable function that will map every $x^* \in \{0,1\}^*$ to a NAND-CIRC program $Q$ such that $F(x^*)=NANDSAT(Q)$.
 
 Let  $x^* \in \{0,1\}^*$ be such a string and let $n=|x^*|$ be its length.
 By [NP-def](){.ref} there exists $V \in \mathbf{P}$ and positive $a \in \N$ such that $F(x^*)=1$  if and only if there exists $w\in \{0,1\}^{n^a}$ satisfying $V(x^*w)=1$.
@@ -455,7 +455,7 @@ We now show both sides of this equivalence.
 
 __Part I: Completeness.__ Suppose that there is $w\in \{0,1\}^n$ s.t. $Q(w)=1$. Let $z\in \{0,1\}^{n+m}$ be defined as follows: for $i\in [n]$, $z_i=w_i$ and for $i\in \{n,n+1,\ldots,n+m\}$ $z_i$ equals the value that is assigned in the $(i-n)$-th line of $Q$ when executed on $w$. Then by construction $z$ satisfies all of the constraints of $\Psi$ (including the constraint that $z_{\ell^*}=NAND(0,0)=1$ since $Q(w)=1$.)
 
-__Part II: Soundness.__ Suppose that there exists $z\in \{0,1\}^{n+m}$ satisfying $\Psi$. Soundness will follow by showing that  $Q(z_0,\ldots,z_{n-1})=1$ (and hence in particular there exists $w\in \{0,1\}^n$, namely $w=z_0\cdots z_{n-1}$, such that $Q(w)=1$). To do this we will prove the following claim $(*)$: for every $\ell \in [m]$, $z_{\ell+n}$ equals the value assigned in the $\ell$-th step of the execution of the program $Q$ on $z_0,\ldots,z_{n-1}$. Note that because $z$ satisfies the constraints of $\Psi$, $(*)$ is sufficient to prove the soundness condition since these constraints imply that the last value assigned to the variable `y_0` in the execution of $Q$ on $z_0\cdots w_{n-1}$  is equal to $1$. To prove $(*)$ suppose, towards a contradiction, that it is false, and let $\ell$ be the smallest number such that $z_{\ell+n}$ is _not_ equal to the value assigned in the $\ell$-th step of the execution of $Q$ on $z_0,\ldots,z_{n-1}$. But since $z$ satisfies the constraints of $\Psi$, we get that $z_{\ell+n}=NAND(z_i,z_j)$ where (by the assumption above that $\ell$ is _smallest_ with this property) these values _do_ correspond to the values last assigned to the variables on the right-hand side of the assignment operator in the $\ell$-th line of the program. But this means that the value assigned in the $\ell$-th step is indeed simply the NAND of $z_i$ and $z_j$, contradicting our assumption on the choice of $\ell$.
+__Part II: Soundness.__ Suppose that there exists $z\in \{0,1\}^{n+m}$ satisfying $\Psi$. Soundness will follow by showing that  $Q(z_0,\ldots,z_{n-1})=1$ (and hence in particular there exists $w\in \{0,1\}^n$, namely $w=z_0\cdots z_{n-1}$, such that $Q(w)=1$). To do this we will prove the following claim $(*)$: for every $\ell \in [m]$, $z_{\ell+n}$ equals the value assigned in the $\ell$-th step of the execution of the program $Q$ on $z_0,\ldots,z_{n-1}$. Note that because $z$ satisfies the constraints of $\Psi$, $(*)$ is sufficient to prove the soundness condition since these constraints imply that the last value assigned to the variable `y_0` in the execution of $Q$ on $z_0\cdots z_{n-1}$  is equal to $1$. To prove $(*)$ suppose, towards a contradiction, that it is false, and let $\ell$ be the smallest number such that $z_{\ell+n}$ is _not_ equal to the value assigned in the $\ell$-th step of the execution of $Q$ on $z_0,\ldots,z_{n-1}$. But since $z$ satisfies the constraints of $\Psi$, we get that $z_{\ell+n}=NAND(z_i,z_j)$ where (by the assumption above that $\ell$ is _smallest_ with this property) these values _do_ correspond to the values last assigned to the variables on the right-hand side of the assignment operator in the $\ell$-th line of the program. But this means that the value assigned in the $\ell$-th step is indeed simply the NAND of $z_i$ and $z_j$, contradicting our assumption on the choice of $\ell$.
 :::
 
 


### PR DESCRIPTION
Fixes:

- Typo in `TRANSITION` function for proof of Theorem 7.11.
- Typo in expression for alphabet of TM configuration Figure 8.12.
- Removes extra parens in Theorem 8.10.
- Misc typos in other chapters.