### PR TITLE
Typo fixes

### DIFF
--- a/lec_07_other_models.md
+++ b/lec_07_other_models.md
@@ -1008,7 +1008,7 @@ The most challenging part is to implement $RECURSE$ using only the operations of
 :::
 
 
-> ### {.theorem title="Enhanced λ calculus equivalent to pure λ calculus." #enhancedvanillalambdathm}
+> ### {.theorem title="Enhanced λ calculus equivalent to pure λ calculus" #enhancedvanillalambdathm}
 There are λ expressions that implement the functions $0$,$1$,$IF$,$PAIR$, $HEAD$, $TAIL$, $NIL$, $ISEMPTY$, $MAP$, $REDUCE$, and $RECURSE$.
 
 

--- a/lec_08_uncomputability.md
+++ b/lec_08_uncomputability.md
@@ -543,8 +543,8 @@ Since this is our first proof by reduction from the Halting problem, we will spe
 INPUT: Turing machine $M$ and string $x$.
 OUTPUT: Turing machine $M'$ such that $M$ halts on $x$ iff $M'$ halts on zero
 
-Procedure{$N_{M,x}$}{$w$} # Description of the T.M. $N_{M,x}$
- Return $EVAL(M,x)$ # Ignore the input $w$, evaluate $M$ on $x$.
+Procedure{$N_{M,x}$}{$z$} # Description of the T.M. $N_{M,x}$
+ Return $EVAL(M,x)$ # Ignore the input $z$, evaluate $M$ on $x$.
 Endprocedure
 
 Return $N_{M,x}$ # We do not execute $N_{M,x}$: only return its description

--- a/lec_19_cryptography.md
+++ b/lec_19_cryptography.md
@@ -773,14 +773,14 @@ Thus this theory that originally was designed to give a _negative result_ (show 
 Suppose that we are given a bit-by-bit encryption of a string $E_k(x_0),\ldots,E_k(x_{n-1})$.
 By design, these ciphertexts are supposed to be "completely unscrutable" and we should not be able to extract any information about $x_i$'s from it.
 However, already in 1978, Rivest,  Adleman and Dertouzos observed that this does not imply that we could not _manipulate_ these encryptions.
-For example, it turns out the security of an encryption scheme does not immediately rule out the ability to take a pair of encryptions $E_k(a)$ and $E_k(b)$ and compute from them $E_k(a NAND b)$ _without knowing the secret key $k$_.
+For example, it turns out the security of an encryption scheme does not immediately rule out the ability to take a pair of encryptions $E_k(a)$ and $E_k(b)$ and compute from them $E_k(NAND(a,b))$ _without knowing the secret key $k$_.
 But do there exist encryption schemes that allow such manipulations? And if so, is this a bug or a feature?
 
 Rivest et al already showed that such encryption schemes could be _immensely_ useful, and their utility has only grown in the age of cloud computing.
 After all, if we can compute NAND then we can use this to run any algorithm $P$ on the encrypted data, and map $E_k(x_0),\ldots,E_k(x_{n-1})$ to $E_k(P(x_0,\ldots,x_{n-1}))$.
 For example, a client could store their secret data $x$ in encrypted form on the cloud, and have the cloud provider perform all sorts of computation on these data without ever revealing to the provider the private key, and so without the provider _ever learning any information_ about the secret data.
 
-The question of _existence_ of such a scheme took much longer time to resolve. Only in 2009 Craig Gentry gave the first construction of an encryption scheme that allows to compute a universal basis of gates on the data (known as a _Fully Homomorphic Encryption scheme_ in crypto parlance).
+The question of the _existence_ of such a scheme took much longer time to resolve. Only in 2009 Craig Gentry gave the first construction of an encryption scheme that allows to compute a universal basis of gates on the data (known as a _Fully Homomorphic Encryption scheme_ in crypto parlance).
 Gentry's scheme left much to be desired in terms of efficiency, and improving upon it has been the focus of an intensive research program that has already seen significant improvements.
 
 ### Multiparty secure computation
@@ -829,7 +829,7 @@ Aside from Grabeel and Zubko, credit to the discovery that the Soviets were reus
 In a [1955 letter to the NSA](https://www.nsa.gov/news-features/declassified-documents/nash-letters/assets/files/nash_letters1.pdf) that only recently came forward,  John Nash proposed an "unbreakable" encryption scheme.
 He wrote _"I hope my handwriting, etc. do not give the impression I am just a crank or circle-squarer....  The significance of this conjecture [that certain encryption schemes are exponentially secure against key recovery attacks] .. is that it is quite feasible to design ciphers that are effectively unbreakable. "_.
 John Nash made seminal contributions in mathematics and game theory, and was awarded both the Abel Prize in mathematics and the Nobel Memorial Prize in Economic Sciences.
-However, he has struggled with mental illness throughout his life. His biography, [A Beautiful Mind](https://en.wikipedia.org/wiki/A_Beautiful_Mind_(book)) was made into a popular movie.
+However, he struggled with mental illness throughout his life. His biography, [A Beautiful Mind](https://en.wikipedia.org/wiki/A_Beautiful_Mind_(book)) was made into a popular movie.
 It is natural to compare Nash's 1955 letter to the NSA to Gödel's letter to von Neumann we mentioned before.
 From the theoretical computer science point of view, the crucial difference is that while Nash informally talks about exponential vs polynomial computation time, he does not mention the word "Turing machine" or other models of computation, and it is not clear if he is aware or not that his conjecture can be made mathematically precise (assuming a formalization of "sufficiently complex types of enciphering").
 

--- a/lec_26_quantum_computing.md
+++ b/lec_26_quantum_computing.md
@@ -658,7 +658,7 @@ The Fourier transform makes it easy to compute the period of a given function: i
 
 ### Shor's Algorithm: A bird's eye view
 
-On input a an integer $M$, Shor's algorithm outputs the prime factorization of $M$ in time that is polynomial in $\log M$.
+On input an integer $M$, Shor's algorithm outputs the prime factorization of $M$ in time that is polynomial in $\log M$.
 The main steps in the algorithm are the following:
 
 
@@ -673,7 +673,7 @@ Hence, factoring $M$ reduces to finding out the period of the function $F_A$.
 
 
 __Step 2: Period finding via the Quantum Fourier Transform.__
-Using a simple trick known as "repeated squaring", it is possible to compute the map $x \mapsto F_A(x)$ in  time polynomial in $m$, which means we can also compute this map using a polynomial number of NAND gates,and so in particular we can generate in polynomial quantum time a quantum state $\rho$ that is (up to normalization) equal to
+Using a simple trick known as "repeated squaring", it is possible to compute the map $x \mapsto F_A(x)$ in  time polynomial in $m$, which means we can also compute this map using a polynomial number of NAND gates, and so in particular we can generate in polynomial quantum time a quantum state $\rho$ that is (up to normalization) equal to
 
 $$
 \sum_{x\in \{0,1\}^m} |x\rangle |F_A(x) \rangle \;\;.
@@ -715,7 +715,7 @@ __Operations:__
 2. If we let $A_0,\ldots,A_{k-1}$ and $p_0,\ldots,p_{k-1}$ be the numbers we chose in the previous step and the corresponding periods of the functions $f_{A_0},\ldots,f_{A_{k-1}}$ then we can use classical results in number theory to obtain from these a non-trivial prime factor $Q$ of $M$ (if such exists). We can now run the algorithm again with the (smaller) input $M/Q$ to obtain all other factors.
 :::
 
-Reducing factoring to order finding is cummbersome, but can be done in polynomial time using a classical computer. The key quantum ingredient in Shor's algorithm is the _quantum fourier transform_.
+Reducing factoring to order finding is cumbersome, but can be done in polynomial time using a classical computer. The key quantum ingredient in Shor's algorithm is the _quantum fourier transform_.
 
 ::: {.remark title="Quantum Fourier Transform" #QFT}
 Despite its name, the Quantum Fourier Transform does _not_ actually give a way to compute the Fourier Transform of a function $f:\{0,1\}^m \rightarrow \R$.


### PR DESCRIPTION
Chapter 8: Equivalent Models of Computation
1. Extra period when rendered: ### {.theorem title="Enhanced λ calculus equivalent to pure λ calculus." #enhancedvanillalambdathm} -> ### {.theorem title="Enhanced λ calculus equivalent to pure λ calculus" #enhancedvanillalambdathm}

Chapter 9: Uncomputability:
1. Syntax: Set input of M' as z instead of w in pseudocode for consistency with the text.

Chapter 19: Cryptography
1. Update for consistency with rest of book "$E_k(a NAND b)$" -> "$E_k(NAND(a,b))$
1. Fix typo: "The question of _existence_ of such a scheme" -> The question of the _existence_ of such a scheme"
1. Update for John Nash section "However, he has struggled" -> "However, he struggled"

Chapter 22: Quantum Computing
1. Fix typo "On input a an integer" -> "On input an integer"
1. Fix typo "NAND gates,and so" -> "NAND gates, and so"
1. Fix typo "cummbersome" -> "cumbersome"